### PR TITLE
Add Last Updated timestamp to Venmo and Splitwise

### DIFF
--- a/client/src/pages/ConnectedAccountsPage.tsx
+++ b/client/src/pages/ConnectedAccountsPage.tsx
@@ -125,16 +125,24 @@ export default function ConnectedAccountsPage({ stripePromise }: { stripePromise
     );
 
     const renderConnectedAccount = (connectedAccount) => {
-        // Handle Venmo data (array)
+        // Handle Venmo data (array of objects with username and last_refreshed_at)
         if (connectedAccount.venmo) {
-            return connectedAccount.venmo.map((venmoUser, index) => {
-                const accountKey = `venmo-${venmoUser}`;
+            return connectedAccount.venmo.map((venmoAccount, index) => {
+                const username = venmoAccount.username;
+                const lastRefreshedAt = venmoAccount.last_refreshed_at;
+                const accountKey = `venmo-${username}`;
                 return (
                     <TableRow key={`${accountKey}-${index}`}>
-                        <TableCell>Venmo - {venmoUser}</TableCell>
+                        <TableCell>Venmo - {username}</TableCell>
                         <TableCell></TableCell>
                         <TableCell></TableCell>
-                        <TableCell></TableCell>
+                        <TableCell>
+                            {lastRefreshedAt ? (
+                                formatDate(lastRefreshedAt)
+                            ) : (
+                                <span className="text-muted-foreground text-sm">—</span>
+                            )}
+                        </TableCell>
                         <TableCell>
                             <Button
                                 variant="ghost"
@@ -150,16 +158,24 @@ export default function ConnectedAccountsPage({ stripePromise }: { stripePromise
             });
         }
 
-        // Handle Splitwise data (array)
+        // Handle Splitwise data (array of objects with username and last_refreshed_at)
         if (connectedAccount.splitwise) {
-            return connectedAccount.splitwise.map((splitwiseUser, index) => {
-                const accountKey = `splitwise-${splitwiseUser}`;
+            return connectedAccount.splitwise.map((splitwiseAccount, index) => {
+                const username = splitwiseAccount.username;
+                const lastRefreshedAt = splitwiseAccount.last_refreshed_at;
+                const accountKey = `splitwise-${username}`;
                 return (
                     <TableRow key={`${accountKey}-${index}`}>
-                        <TableCell>Splitwise - {splitwiseUser}</TableCell>
+                        <TableCell>Splitwise - {username}</TableCell>
                         <TableCell></TableCell>
                         <TableCell></TableCell>
-                        <TableCell></TableCell>
+                        <TableCell>
+                            {lastRefreshedAt ? (
+                                formatDate(lastRefreshedAt)
+                            ) : (
+                                <span className="text-muted-foreground text-sm">—</span>
+                            )}
+                        </TableCell>
                         <TableCell>
                             <Button
                                 variant="ghost"

--- a/client/src/pages/__tests__/ConnectedAccountsPage.test.tsx
+++ b/client/src/pages/__tests__/ConnectedAccountsPage.test.tsx
@@ -22,8 +22,8 @@ jest.mock('../../components/FinancialConnectionsForm', () => ({ fcsess_secret, s
 const mockStripePromise = Promise.resolve(null);
 
 const mockConnectedAccounts = [
-    { venmo: ['user1'] },
-    { splitwise: ['swuser1'] },
+    { venmo: [{ username: 'user1', last_refreshed_at: 1700000000 }] },
+    { splitwise: [{ username: 'swuser1', last_refreshed_at: 1700000000 }] },
     {
         stripe: [
             {

--- a/server/alembic/versions/a1b2c3d4e5f6_add_integration_accounts_table.py
+++ b/server/alembic/versions/a1b2c3d4e5f6_add_integration_accounts_table.py
@@ -1,0 +1,44 @@
+"""Add integration_accounts table
+
+Revision ID: a1b2c3d4e5f6
+Revises: fb7a20ffd5fe
+Create Date: 2025-11-22 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, Sequence[str], None] = "fb7a20ffd5fe"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        "integration_accounts",
+        sa.Column("id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "source",
+            sa.Enum("venmo", "splitwise", name="integration_source"),
+            nullable=False,
+        ),
+        sa.Column("display_name", sa.String(length=255), nullable=False),
+        sa.Column("last_refreshed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("source"),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table("integration_accounts")
+    op.execute("DROP TYPE IF EXISTS integration_source")

--- a/server/models/sql_models.py
+++ b/server/models/sql_models.py
@@ -50,6 +50,33 @@ class BankAccount(Base):
     )
 
 
+class IntegrationAccount(Base):
+    """
+    Metadata for integration accounts (Venmo, Splitwise).
+
+    Unlike BankAccounts which are fetched from Stripe, these track
+    user-level integrations with external services. Stores the display
+    name and when data was last refreshed from the integration.
+    """
+
+    __tablename__ = "integration_accounts"
+
+    id = Column(String(255), primary_key=True)  # intacc_xxx
+    source = Column(
+        Enum("venmo", "splitwise", name="integration_source"),
+        nullable=False,
+        unique=True,
+    )
+    display_name = Column(String(255), nullable=False)  # Username or full name
+    last_refreshed_at = Column(TIMESTAMP(timezone=True), nullable=True)  # When data was last fetched
+    created_at = Column(TIMESTAMP(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+
 class User(Base):
     __tablename__ = "users"
 

--- a/server/tests/test_application.py
+++ b/server/tests/test_application.py
@@ -248,11 +248,15 @@ class TestApplicationRoutes:
 
             # Check Venmo data
             venmo_data = next(item for item in data if "venmo" in item)
-            assert venmo_data["venmo"] == ["test_user"]
+            assert len(venmo_data["venmo"]) == 1
+            assert venmo_data["venmo"][0]["username"] == "test_user"
+            assert "last_refreshed_at" in venmo_data["venmo"][0]
 
             # Check Splitwise data
             splitwise_data = next(item for item in data if "splitwise" in item)
-            assert splitwise_data["splitwise"] == ["John Doe"]
+            assert len(splitwise_data["splitwise"]) == 1
+            assert splitwise_data["splitwise"][0]["username"] == "John Doe"
+            assert "last_refreshed_at" in splitwise_data["splitwise"][0]
 
             # Check Stripe data
             stripe_data = next(item for item in data if "stripe" in item)


### PR DESCRIPTION
- Add IntegrationAccount model to track Venmo/Splitwise account metadata
- Create alembic migration for integration_accounts table
- Add upsert_integration_account and get_integration_account helpers
- Update refresh_venmo() and refresh_splitwise() to record last_refreshed_at
- Update /api/connected_accounts to return last_refreshed_at timestamps
- Update ConnectedAccountsPage.tsx to display Last Updated for Venmo/Splitwise
- Update server and client tests to match new API response format