### PR TITLE
Sort review line items by calendar date and description

### DIFF
--- a/server/helpers.py
+++ b/server/helpers.py
@@ -97,11 +97,16 @@ def iso_8601_to_posix(date: str) -> float:
         raise ValueError("Invalid ISO 8601 format") from exc
 
 
-def sort_by_date_amount_descending(line_items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def sort_by_date_description(line_items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Input a list of dictionaries representing LineItems (not actual LineItem objects)
     """
-    line_items.sort(reverse=True, key=lambda line_item: (line_item["date"], abs(line_item["amount"])))
+    line_items.sort(
+        key=lambda line_item: (
+            -datetime.fromtimestamp(line_item["date"], timezone.utc).date().toordinal(),
+            line_item["description"].casefold(),
+        )
+    )
     return line_items
 
 

--- a/server/resources/line_item.py
+++ b/server/resources/line_item.py
@@ -6,7 +6,7 @@ from flask import Blueprint, Response, jsonify, request
 from flask_jwt_extended import jwt_required
 
 from dao import get_all_line_items, get_line_item_by_id
-from helpers import sort_by_date_amount_descending, str_to_bool
+from helpers import sort_by_date_description, str_to_bool
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +103,7 @@ def all_line_items(
         filters["event_id"] = {"$exists": False}
 
     line_items: List[Dict[str, Any]] = get_all_line_items(filters)
-    line_items = sort_by_date_amount_descending(line_items)
+    line_items = sort_by_date_description(line_items)
     return line_items
 
 

--- a/server/tests/test_line_item.py
+++ b/server/tests/test_line_item.py
@@ -1,3 +1,5 @@
+from datetime import UTC, datetime
+
 import pytest
 
 from resources.line_item import LineItem, all_line_items
@@ -252,7 +254,7 @@ class TestLineItemFunctions:
             test_line_items = [
                 {
                     "id": "line_item_1",
-                    "date": 1234567890,
+                    "date": datetime(2026, 5, 29, tzinfo=UTC).timestamp(),
                     "responsible_party": "John Doe",
                     "payment_method": "Cash",
                     "description": "Test transaction 1",
@@ -260,7 +262,7 @@ class TestLineItemFunctions:
                 },
                 {
                     "id": "line_item_2",
-                    "date": 1234567891,
+                    "date": datetime(2026, 5, 30, tzinfo=UTC).timestamp(),
                     "responsible_party": "Jane Smith",
                     "payment_method": "Venmo",
                     "description": "Test transaction 2",
@@ -281,6 +283,46 @@ class TestLineItemFunctions:
             assert result[1]["description"] == "Test transaction 1"
             assert result[0]["id"] == created_items[1].id
             assert result[1]["id"] == created_items[0].id
+
+    def test_all_line_items_ignores_time_and_sorts_same_day_items_by_description(self, flask_app, pg_session):
+        """All line items sorts days descending and same-day descriptions ascending"""
+        from tests.test_helpers import setup_test_line_item
+
+        with flask_app.app_context():
+            test_line_items = [
+                {
+                    "id": "line_item_1",
+                    "date": datetime(2026, 5, 29, 23, tzinfo=UTC).timestamp(),
+                    "responsible_party": "John Doe",
+                    "payment_method": "Cash",
+                    "description": "Coffee",
+                    "amount": 5,
+                },
+                {
+                    "id": "line_item_2",
+                    "date": datetime(2026, 5, 29, 1, tzinfo=UTC).timestamp(),
+                    "responsible_party": "Jane Smith",
+                    "payment_method": "Cash",
+                    "description": "Bagels",
+                    "amount": 10,
+                },
+                {
+                    "id": "line_item_3",
+                    "date": datetime(2026, 5, 30, tzinfo=UTC).timestamp(),
+                    "responsible_party": "Bob Johnson",
+                    "payment_method": "Cash",
+                    "description": "Dinner",
+                    "amount": 20,
+                },
+            ]
+
+            for item in test_line_items:
+                setup_test_line_item(pg_session, item)
+            pg_session.commit()
+
+            result = all_line_items()
+
+            assert [item["description"] for item in result] == ["Dinner", "Bagels", "Coffee"]
 
     def test_payment_method_filter_returns_matching_items(self, flask_app, pg_session):
         """Payment method filter returns only matching line items"""


### PR DESCRIPTION
## Summary
- Changed the shared line-item ordering to use UTC calendar day instead of full timestamp, so hour/minute differences no longer affect review order.
- Switched the secondary sort to description, giving a stable alphabetical tie-breaker within the same day.
- Added regression coverage for same-day ordering and updated the existing ordering expectation to match the new behavior.

## Testing
- `make lint`
- `uv run python -m pytest`
- Full server test suite passed: `235 passed`