### PR TITLE
Add JWT auth to Stripe endpoints and secure scheduled refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -211,6 +211,7 @@ External API data follows this flow:
 - `SPLITWISE_CONSUMER_KEY`, `SPLITWISE_CONSUMER_SECRET`, `SPLITWISE_API_KEY` - Splitwise OAuth
 - `JWT_SECRET_KEY` - JWT signing key (defaults to `testSecretKey123` for development)
 - `JWT_COOKIE_DOMAIN` - Cookie domain for JWT (for cross-origin authentication)
+- `SCHEDULED_REFRESH_SECRET` - Shared secret for the cron-triggered `/api/refresh/scheduled` endpoint (cron must send it in the `X-Refresh-Secret` header; endpoint rejects all requests if unset)
 - `CORS_ALLOWED_ORIGINS` - Comma-separated list of allowed origins (defaults to `http://dev.localhost:5173`)
 - `LOG_LEVEL` - Logging level (defaults to `INFO`)
 

--- a/server/application.py
+++ b/server/application.py
@@ -1,4 +1,5 @@
 import logging
+import secrets
 import sys
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -22,6 +23,7 @@ from constants import (
     JWT_COOKIE_DOMAIN,
     JWT_SECRET_KEY,
     LOG_LEVEL,
+    SCHEDULED_REFRESH_SECRET,
     SPLITWISE_API_KEY,
     SPLITWISE_CONSUMER_KEY,
     SPLITWISE_CONSUMER_SECRET,
@@ -166,13 +168,19 @@ def index_api() -> tuple[Response, int]:
 
 @application.route("/api/refresh/scheduled")
 def schedule_refresh_api() -> tuple[Response, int]:
+    # This endpoint is called by an unauthenticated cron, so it's protected by a
+    # shared secret header instead of a JWT. compare_digest prevents timing attacks.
+    provided_secret = request.headers.get("X-Refresh-Secret", "")
+    if not SCHEDULED_REFRESH_SECRET or not secrets.compare_digest(provided_secret, SCHEDULED_REFRESH_SECRET):
+        return jsonify({"error": "Unauthorized"}), 401
+
     logger.info("Initiating scheduled refresh at " + str(datetime.now()))
     try:
         refresh_all()
         create_consistent_line_items()
     except Exception as e:
         logger.error("Error refreshing all: " + str(e))
-        return jsonify({"error": str(e)}), 500
+        return jsonify({"error": "Refresh failed"}), 500
     return jsonify({"message": "success"}), 200
 
 

--- a/server/constants.py
+++ b/server/constants.py
@@ -43,6 +43,8 @@ SPLITWISE_CONSUMER_KEY = os.getenv("SPLITWISE_CONSUMER_KEY")
 SPLITWISE_CONSUMER_SECRET = os.getenv("SPLITWISE_CONSUMER_SECRET")
 SPLITWISE_API_KEY = os.getenv("SPLITWISE_API_KEY")
 JWT_SECRET_KEY = os.getenv("JWT_SECRET_KEY")
+# Shared secret required in the X-Refresh-Secret header to trigger the scheduled refresh endpoint
+SCHEDULED_REFRESH_SECRET = os.getenv("SCHEDULED_REFRESH_SECRET")
 JWT_COOKIE_DOMAIN = os.getenv("JWT_COOKIE_DOMAIN")
 # CORS configuration - comma-separated list of allowed origins
 CORS_ALLOWED_ORIGINS = os.getenv("CORS_ALLOWED_ORIGINS", "http://dev.localhost:5173").split(",")

--- a/server/resources/line_item.py
+++ b/server/resources/line_item.py
@@ -108,6 +108,7 @@ def all_line_items(
 
 
 @line_items_blueprint.route("/api/line_items/<line_item_id>", methods=["GET"])
+@jwt_required()
 def get_line_item_api(line_item_id: str) -> tuple[Response, int]:
     """
     Get A Line Item

--- a/server/resources/stripe.py
+++ b/server/resources/stripe.py
@@ -245,16 +245,20 @@ def subscribe_to_account_api() -> tuple[Response, int]:
         return jsonify(error=str(e)), 500
 
 
+def refresh_account(account_id: str) -> None:
+    logger.info(f"Refreshing {account_id}")
+    account: stripe.financial_connections.Account = stripe.financial_connections.Account.retrieve(account_id)
+    account["can_relink"] = check_can_relink(account)
+
+    with SessionLocal.begin() as db:
+        bulk_upsert_bank_accounts(db, [account])
+
+
 @stripe_blueprint.route("/api/refresh_account/<account_id>")
+@jwt_required()
 def refresh_account_api(account_id: str) -> tuple[Response, int]:
     try:
-        logger.info(f"Refreshing {account_id}")
-        account: stripe.financial_connections.Account = stripe.financial_connections.Account.retrieve(account_id)
-        account["can_relink"] = check_can_relink(account)
-
-        with SessionLocal.begin() as db:
-            bulk_upsert_bank_accounts(db, [account])
-
+        refresh_account(account_id)
         return jsonify({"data": "success"}), 200
     except Exception as e:
         return jsonify(error=str(e)), 500
@@ -276,50 +280,53 @@ def relink_account_api(account_id: str) -> tuple[Response, int]:
         return jsonify(error=str(e)), 500
 
 
-@stripe_blueprint.route("/api/refresh_transactions/<account_id>")
-def refresh_transactions_api(account_id: str) -> tuple[Response, int]:
+def refresh_transactions(account_id: str) -> None:
     logger.info(f"Getting Transactions for {account_id}")
     # TODO: This gets all transactions ever. We should only get those that we don't have
+    has_more: bool = True
+    starting_after = ""
+    all_transactions: List[Dict[str, Any]] = []
+    stripe.api_key = STRIPE_API_KEY
+    stripe.api_version = "2022-08-01; financial_connections_transactions_beta=v1"
+
+    while has_more:
+        transactions_list_params = {
+            "account": account_id,
+            "limit": 100,
+        }
+        if starting_after:
+            transactions_list_params["starting_after"] = starting_after
+
+        transactions_list_object = stripe.financial_connections.Transaction.list(**transactions_list_params)
+
+        transactions = transactions_list_object.data
+
+        for transaction in transactions:
+            if transaction.status == "posted":
+                all_transactions.append(transaction)
+            elif transaction.status == "pending":
+                logger.info(
+                    f"Pending Transaction: {transaction.description} | "
+                    + f"{cents_to_dollars(flip_amount(transaction.amount))}"
+                )
+
+        has_more = transactions_list_object.has_more
+        starting_after = transactions[-1].id if transactions else ""
+
+    if all_transactions:
+        with SessionLocal.begin() as db:
+            bulk_upsert_transactions(db, all_transactions, source="stripe_api")
+
+    # Best-effort: fetch latest balance for this account (won't fail transaction refresh)
+    refresh_account_balances(account_ids=[account_id])
+
+
+@stripe_blueprint.route("/api/refresh_transactions/<account_id>")
+@jwt_required()
+def refresh_transactions_api(account_id: str) -> tuple[Response, int]:
     try:
-        has_more: bool = True
-        starting_after = ""
-        all_transactions: List[Dict[str, Any]] = []
-        stripe.api_key = STRIPE_API_KEY
-        stripe.api_version = "2022-08-01; financial_connections_transactions_beta=v1"
-
-        while has_more:
-            transactions_list_params = {
-                "account": account_id,
-                "limit": 100,
-            }
-            if starting_after:
-                transactions_list_params["starting_after"] = starting_after
-
-            transactions_list_object = stripe.financial_connections.Transaction.list(**transactions_list_params)
-
-            transactions = transactions_list_object.data
-
-            for transaction in transactions:
-                if transaction.status == "posted":
-                    all_transactions.append(transaction)
-                elif transaction.status == "pending":
-                    logger.info(
-                        f"Pending Transaction: {transaction.description} | "
-                        + f"{cents_to_dollars(flip_amount(transaction.amount))}"
-                    )
-
-            has_more = transactions_list_object.has_more
-            starting_after = transactions[-1].id if transactions else ""
-
-        if all_transactions:
-            with SessionLocal.begin() as db:
-                bulk_upsert_transactions(db, all_transactions, source="stripe_api")
-
-        # Best-effort: fetch latest balance for this account (won't fail transaction refresh)
-        refresh_account_balances(account_ids=[account_id])
-
+        refresh_transactions(account_id)
         return jsonify("Refreshed Stripe Connection for Given Account"), 200
-
     except Exception as e:
         return jsonify(error=str(e)), 500
 
@@ -328,8 +335,8 @@ def refresh_stripe() -> None:
     logger.info("Refreshing Stripe Data")
     bank_accounts: List[Dict[str, Any]] = get_all_bank_accounts(None)
     for account in bank_accounts:
-        refresh_account_api(account["id"])
-        refresh_transactions_api(account["id"])
+        refresh_account(account["id"])
+        refresh_transactions(account["id"])
     stripe_to_line_items()
     # Best-effort: refresh balances for all accounts after transactions updated
     refresh_account_balances()

--- a/server/tests/test_application.py
+++ b/server/tests/test_application.py
@@ -78,23 +78,45 @@ class TestApplicationRoutes:
 
     def test_scheduled_refresh_triggers_data_sync(self, test_client, mocker):
         """Scheduled refresh triggers data refresh and line item creation"""
+        mocker.patch("application.SCHEDULED_REFRESH_SECRET", "test_refresh_secret")
         mock_refresh_all = mocker.patch("application.refresh_all")
         mock_create_consistent = mocker.patch("application.create_consistent_line_items")
 
-        response = test_client.get("/api/refresh/scheduled")
+        response = test_client.get("/api/refresh/scheduled", headers={"X-Refresh-Secret": "test_refresh_secret"})
 
         assert response.status_code == 200
         mock_refresh_all.assert_called_once()
         mock_create_consistent.assert_called_once()
 
+    def test_scheduled_refresh_rejects_missing_or_wrong_secret(self, test_client, mocker):
+        """Scheduled refresh returns 401 when the secret header is missing or wrong"""
+        mocker.patch("application.SCHEDULED_REFRESH_SECRET", "test_refresh_secret")
+        mock_refresh_all = mocker.patch("application.refresh_all")
+
+        assert test_client.get("/api/refresh/scheduled").status_code == 401
+        assert test_client.get("/api/refresh/scheduled", headers={"X-Refresh-Secret": "wrong"}).status_code == 401
+        mock_refresh_all.assert_not_called()
+
+    def test_scheduled_refresh_rejects_all_requests_when_secret_unconfigured(self, test_client, mocker):
+        """Scheduled refresh returns 401 for all requests when no secret is configured"""
+        mocker.patch("application.SCHEDULED_REFRESH_SECRET", None)
+        mock_refresh_all = mocker.patch("application.refresh_all")
+
+        response = test_client.get("/api/refresh/scheduled", headers={"X-Refresh-Secret": ""})
+
+        assert response.status_code == 401
+        mock_refresh_all.assert_not_called()
+
     def test_scheduled_refresh_returns_500_on_error(self, test_client, mocker):
-        """Scheduled refresh returns 500 when data refresh fails"""
+        """Scheduled refresh returns 500 without leaking error details when data refresh fails"""
+        mocker.patch("application.SCHEDULED_REFRESH_SECRET", "test_refresh_secret")
         mock_refresh_all = mocker.patch("application.refresh_all", side_effect=Exception("Test error"))
         mock_create_consistent = mocker.patch("application.create_consistent_line_items")
 
-        response = test_client.get("/api/refresh/scheduled")
+        response = test_client.get("/api/refresh/scheduled", headers={"X-Refresh-Secret": "test_refresh_secret"})
 
         assert response.status_code == 500
+        assert "Test error" not in response.get_data(as_text=True)
         mock_refresh_all.assert_called_once()
         mock_create_consistent.assert_not_called()
 

--- a/server/tests/test_line_item.py
+++ b/server/tests/test_line_item.py
@@ -226,7 +226,10 @@ class TestLineItemAPI:
             line_item_id = all_line_items[0]["id"]
 
         # Test API call
-        response = test_client.get(f"/api/line_items/{line_item_id}")
+        response = test_client.get(
+            f"/api/line_items/{line_item_id}",
+            headers={"Authorization": f"Bearer {jwt_token}"},
+        )
 
         assert response.status_code == 200
         data = response.get_json()
@@ -236,9 +239,12 @@ class TestLineItemAPI:
         assert data["description"] == "Test transaction"
         assert data["amount"] == 100
 
-    def test_nonexistent_line_item_returns_404(self, test_client):
+    def test_nonexistent_line_item_returns_404(self, test_client, jwt_token):
         """Requesting a nonexistent line item returns 404"""
-        response = test_client.get("/api/line_items/nonexistent_id")
+        response = test_client.get(
+            "/api/line_items/nonexistent_id",
+            headers={"Authorization": f"Bearer {jwt_token}"},
+        )
 
         assert response.status_code == 404
         data = response.get_json()

--- a/server/tests/test_stripe.py
+++ b/server/tests/test_stripe.py
@@ -273,7 +273,7 @@ class TestStripeAPI:
             assert response.status_code == 200
             assert response.get_data(as_text=True).strip() == '"succeeded"'
 
-    def test_refresh_account_updates_account_data(self, flask_app, mocker):
+    def test_refresh_account_updates_account_data(self, flask_app, jwt_token, mocker):
         """Refreshing account updates stored account data"""
         mocker.patch("resources.stripe.STRIPE_API_KEY", "test_api_key")
         mocker.patch("resources.stripe.STRIPE_CUSTOMER_ID", "test_customer_id")
@@ -289,7 +289,10 @@ class TestStripeAPI:
             mock_account.__getitem__.side_effect = lambda k: getattr(mock_account, k)
             mock_retrieve.return_value = mock_account
 
-            response = flask_app.test_client().get("/api/refresh_account/fca_test123")
+            response = flask_app.test_client().get(
+                "/api/refresh_account/fca_test123",
+                headers={"Authorization": f"Bearer {jwt_token}"},
+            )
 
             assert response.status_code == 200
             data = response.get_json()
@@ -357,7 +360,7 @@ class TestStripeAPI:
             data = response.get_json()
             assert not data["relink_required"]
 
-    def test_refresh_transactions_fetches_new_transactions(self, flask_app, mocker):
+    def test_refresh_transactions_fetches_new_transactions(self, flask_app, jwt_token, mocker):
         """Refreshing transactions fetches new transactions from Stripe"""
         mocker.patch("resources.stripe.STRIPE_API_KEY", "test_api_key")
         mocker.patch("resources.stripe.STRIPE_CUSTOMER_ID", "test_customer_id")
@@ -380,7 +383,10 @@ class TestStripeAPI:
             mocked_list_object.has_more = False
             mock_list.return_value = mocked_list_object
 
-            response = flask_app.test_client().get("/api/refresh_transactions/fca_test123")
+            response = flask_app.test_client().get(
+                "/api/refresh_transactions/fca_test123",
+                headers={"Authorization": f"Bearer {jwt_token}"},
+            )
 
             assert response.status_code == 200
             assert "Refreshed Stripe Connection for Given Account" in response.get_data(as_text=True)
@@ -390,8 +396,8 @@ class TestStripeFunctions:
     def test_refresh_stripe_syncs_each_account(self, flask_app, mocker):
         """Refresh stripe syncs each stored bank account"""
         with flask_app.app_context():
-            mock_refresh_account = mocker.patch("resources.stripe.refresh_account_api")
-            mock_refresh_transactions = mocker.patch("resources.stripe.refresh_transactions_api")
+            mock_refresh_account = mocker.patch("resources.stripe.refresh_account")
+            mock_refresh_transactions = mocker.patch("resources.stripe.refresh_transactions")
             mock_convert = mocker.patch("resources.stripe.stripe_to_line_items")
 
             # Insert test account data
@@ -418,8 +424,8 @@ class TestStripeFunctions:
     def test_no_accounts_skips_sync_but_converts_line_items(self, flask_app, mocker):
         """No accounts skips sync but still converts existing transactions"""
         with flask_app.app_context():
-            mock_refresh_account = mocker.patch("resources.stripe.refresh_account_api")
-            mock_refresh_transactions = mocker.patch("resources.stripe.refresh_transactions_api")
+            mock_refresh_account = mocker.patch("resources.stripe.refresh_account")
+            mock_refresh_transactions = mocker.patch("resources.stripe.refresh_transactions")
             mock_convert = mocker.patch("resources.stripe.stripe_to_line_items")
 
             # Call the function with no accounts
@@ -670,8 +676,8 @@ class TestStripeIntegration:
     def test_complete_workflow_syncs_accounts_and_creates_line_items(self, flask_app, mocker):
         """Complete workflow syncs accounts, transactions, and creates line items"""
         with flask_app.app_context():
-            mock_refresh_account = mocker.patch("resources.stripe.refresh_account_api")
-            mock_refresh_transactions = mocker.patch("resources.stripe.refresh_transactions_api")
+            mock_refresh_account = mocker.patch("resources.stripe.refresh_account")
+            mock_refresh_transactions = mocker.patch("resources.stripe.refresh_transactions")
             mocker.patch("resources.stripe.bulk_upsert_line_items")
 
             # Insert test account


### PR DESCRIPTION
## Summary
This PR adds authentication and security improvements to the Stripe API endpoints and the scheduled refresh endpoint. The main changes are:

1. **Extract reusable functions from API endpoints**: Created `refresh_account()` and `refresh_transactions()` helper functions that contain the core logic, allowing them to be called both from API endpoints and from the internal `refresh_stripe()` function without JWT requirements.

2. **Add JWT authentication to Stripe endpoints**: Protected `/api/refresh_account/<account_id>` and `/api/refresh_transactions/<account_id>` with `@jwt_required()` decorator to ensure only authenticated users can trigger these operations.

3. **Secure scheduled refresh endpoint**: The `/api/refresh/scheduled` endpoint is called by an unauthenticated cron job, so it's now protected by a shared secret header (`X-Refresh-Secret`) instead of JWT. Uses `secrets.compare_digest()` to prevent timing attacks.

4. **Hide error details in scheduled refresh**: The scheduled refresh endpoint now returns a generic error message instead of leaking exception details, improving security.

5. **Update tests**: 
   - Added JWT token headers to Stripe endpoint tests
   - Added tests for scheduled refresh secret validation (missing, wrong, and unconfigured scenarios)
   - Updated mocks to call the new helper functions instead of API endpoints
   - Added JWT token headers to line item endpoint tests

## Key Changes
- `server/resources/stripe.py`: Extracted `refresh_account()` and `refresh_transactions()` functions; added `@jwt_required()` to API endpoints; updated `refresh_stripe()` to call helper functions
- `server/application.py`: Added shared secret validation to `/api/refresh/scheduled` endpoint with timing-attack-safe comparison
- `server/constants.py`: Added `SCHEDULED_REFRESH_SECRET` environment variable
- `server/tests/test_stripe.py`: Updated tests to use JWT tokens and mock helper functions
- `server/tests/test_application.py`: Added comprehensive tests for scheduled refresh secret validation
- `server/tests/test_line_item.py`: Added JWT token headers to line item endpoint tests

## Implementation Details
- The helper functions (`refresh_account`, `refresh_transactions`) contain no error handling—exceptions bubble up to the API endpoints for proper HTTP response handling
- The scheduled refresh endpoint uses `secrets.compare_digest()` for constant-time comparison to prevent timing attacks on the shared secret
- Internal calls to refresh functions from `refresh_stripe()` bypass JWT requirements by calling the helper functions directly

https://claude.ai/code/session_0174afvHgSnB4PpRwkh3ggXE