### PR TITLE
Support re-importing edited/deleted transactions and line items

### DIFF
--- a/server/application.py
+++ b/server/application.py
@@ -47,7 +47,7 @@ from resources.splitwise import (
 )
 from resources.stripe import (
     refresh_stripe,
-    refresh_transactions_api,
+    refresh_transactions,
     stripe_blueprint,
     stripe_to_line_items,
 )
@@ -211,7 +211,7 @@ def refresh_single_account_api() -> tuple[Response, int]:
             return jsonify({"error": "accountId and source are required"}), 400
 
         if source == "stripe":
-            refresh_transactions_api(account_id)
+            refresh_transactions(account_id)
             stripe_to_line_items()
         elif source == "venmo":
             refresh_venmo()

--- a/server/dao.py
+++ b/server/dao.py
@@ -74,11 +74,11 @@ def get_categorized_data() -> List[Dict[str, Any]]:
             .subquery()
         )
 
-        # Subquery: first line item amount per event (for duplicates)
-        first_li_subq = (
+        # Subquery: minimum line item amount per event (for duplicates)
+        min_li_subq = (
             db.query(
                 EventLineItem.event_id,
-                func.min(LineItem.amount).label("first_amount"),
+                func.min(LineItem.amount).label("min_amount"),
             )
             .join(LineItem, EventLineItem.line_item_id == LineItem.id)
             .group_by(EventLineItem.event_id)
@@ -91,13 +91,13 @@ def get_categorized_data() -> List[Dict[str, Any]]:
                 Event.date,
                 Category.name.label("category"),
                 case(
-                    (Event.is_duplicate == True, first_li_subq.c.first_amount),  # noqa: E712
+                    (Event.is_duplicate == True, min_li_subq.c.min_amount),  # noqa: E712
                     else_=total_subq.c.total,
                 ).label("amount"),
             )
             .join(Category, Event.category_id == Category.id)
             .outerjoin(total_subq, total_subq.c.event_id == Event.id)
-            .outerjoin(first_li_subq, first_li_subq.c.event_id == Event.id)
+            .outerjoin(min_li_subq, min_li_subq.c.event_id == Event.id)
             .all()
         )
 

--- a/server/models/sql_models.py
+++ b/server/models/sql_models.py
@@ -191,7 +191,9 @@ class Event(Base):
         if not self.line_items:
             return Decimal("0.00")
         if self.is_duplicate:
-            return self.line_items[0].amount
+            # Count only one side of the duplicate; min() keeps this deterministic
+            # and consistent with the monthly breakdown query in dao.py
+            return min(li.amount for li in self.line_items)
         return sum(li.amount for li in self.line_items)
 
 

--- a/server/resources/event.py
+++ b/server/resources/event.py
@@ -123,8 +123,8 @@ def update_event_api(event_id: str) -> tuple[Response, int]:
         "name": update_data.get("name", event.get("name", "")),
         "category": update_data.get("category", event.get("category")),
         "line_items": update_data["line_items"],
-        "is_duplicate_transaction": update_data.get("is_duplicate_transaction", False),
-        "tags": update_data.get("tags", []),
+        "is_duplicate_transaction": update_data.get("is_duplicate_transaction", event.get("is_duplicate_transaction", False)),
+        "tags": update_data.get("tags", event.get("tags", [])),
     }
 
     if update_data.get("date"):

--- a/server/resources/event.py
+++ b/server/resources/event.py
@@ -80,7 +80,8 @@ def post_event_api() -> tuple[Response, int]:
         new_event["date"] = earliest_line_item["date"]
 
     if new_event.get("is_duplicate_transaction"):
-        new_event["amount"] = line_items[0]["amount"]
+        # Count only one side of the duplicate; min() matches Event.total_amount and the monthly breakdown
+        new_event["amount"] = min(line_item["amount"] for line_item in line_items)
     else:
         new_event["amount"] = sum(line_item["amount"] for line_item in line_items)
 
@@ -138,7 +139,7 @@ def update_event_api(event_id: str) -> tuple[Response, int]:
 
     # Calculate updated amount for response
     if event_dict.get("is_duplicate_transaction"):
-        updated_amount = line_items[0]["amount"]
+        updated_amount = min(li["amount"] for li in line_items)
     else:
         updated_amount = sum(li["amount"] for li in line_items)
 

--- a/server/resources/splitwise.py
+++ b/server/resources/splitwise.py
@@ -21,7 +21,11 @@ from resources.schemas.splitwise import (
     SplitwiseExpenseCreateResponse,
     SplitwiseFriendListResponse,
 )
-from utils.pg_bulk_ops import bulk_upsert_line_items, bulk_upsert_transactions
+from utils.pg_bulk_ops import (
+    bulk_upsert_line_items,
+    bulk_upsert_transactions,
+    delete_transactions_for_removed_sources,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -234,24 +238,26 @@ def build_splitwise_users(amount: Decimal, current_user_id: int, owed_shares: Di
 
 def refresh_splitwise() -> None:
     logger.info("Refreshing Splitwise Data")
-    expenses: List[Any] = splitwise_client.getExpenses(limit=LIMIT, dated_after=MOVING_DATE)
 
-    # Collect all non-deleted expenses for bulk upsert
-    all_expenses: List[Any] = []
-    deleted_count = 0
-    for expense in expenses:
-        # TODO: What if an expense is deleted? What if it's part of an event?
-        # Should I send a notification?
-        if expense.deleted_at is not None:
-            deleted_count += 1
-            continue
-        all_expenses.append(expense)
+    # Page through all expenses; a single call is capped at LIMIT results
+    expenses: List[Any] = []
+    offset = 0
+    while True:
+        page: List[Any] = splitwise_client.getExpenses(limit=LIMIT, offset=offset, dated_after=MOVING_DATE)
+        expenses.extend(page)
+        if len(page) < LIMIT:
+            break
+        offset += LIMIT
 
-    # Bulk upsert all collected expenses at once
-    if all_expenses:
+    all_expenses: List[Any] = [expense for expense in expenses if expense.deleted_at is None]
+    deleted_source_ids: List[str] = [str(expense.id) for expense in expenses if expense.deleted_at is not None]
+
+    if all_expenses or deleted_source_ids:
         with SessionLocal.begin() as db:
             bulk_upsert_transactions(db, all_expenses, source="splitwise_api")
-        logger.info(f"Refreshed {len(all_expenses)} Splitwise expenses (skipped {deleted_count} deleted)")
+            # Remove expenses deleted in Splitwise (unless already reviewed into an event)
+            delete_transactions_for_removed_sources(db, "splitwise_api", deleted_source_ids)
+        logger.info(f"Refreshed {len(all_expenses)} Splitwise expenses ({len(deleted_source_ids)} deleted upstream)")
     else:
         logger.info("No new Splitwise expenses to refresh")
 

--- a/server/tests/test_application.py
+++ b/server/tests/test_application.py
@@ -144,7 +144,7 @@ class TestApplicationRoutes:
 
     def test_refresh_account_syncs_stripe_transactions(self, test_client, jwt_token, mocker):
         """Refresh account endpoint syncs Stripe transactions"""
-        mock_refresh_transactions = mocker.patch("application.refresh_transactions_api")
+        mock_refresh_transactions = mocker.patch("application.refresh_transactions")
         mock_stripe_to_line_items = mocker.patch("application.stripe_to_line_items")
 
         response = test_client.post(
@@ -214,7 +214,7 @@ class TestApplicationRoutes:
 
     def test_refresh_account_returns_500_on_error(self, test_client, jwt_token, mocker):
         """Refresh account endpoint returns 500 when refresh fails"""
-        mocker.patch("application.refresh_transactions_api", side_effect=Exception("Test error"))
+        mocker.patch("application.refresh_transactions", side_effect=Exception("Test error"))
 
         response = test_client.post(
             "/api/refresh/account",

--- a/server/tests/test_event.py
+++ b/server/tests/test_event.py
@@ -590,6 +590,48 @@ class TestEventAPI:
         data = response.get_json()
         assert data["error"] == "Event must have at least one line item"
 
+    def test_updating_event_without_tags_or_duplicate_flag_preserves_existing_values(
+        self,
+        test_client,
+        jwt_token,
+        flask_app,
+        create_line_item_via_manual,
+        create_event_via_api,
+    ):
+        """Omitting tags/is_duplicate_transaction in a PUT falls back to existing event values"""
+        create_line_item_via_manual(date="2009-02-13", person="Person1", description="Transaction 1", amount=100)
+
+        with flask_app.app_context():
+            from dao import get_all_line_items
+
+            all_line_items = get_all_line_items(None)
+            line_item_ids = [item["id"] for item in all_line_items]
+
+        event_response = create_event_via_api(
+            {
+                "name": "Original Event",
+                "category": "Dining",
+                "date": "2009-02-13",
+                "line_items": line_item_ids,
+                "tags": ["vacation"],
+                "is_duplicate_transaction": True,
+            }
+        )
+        event_id = event_response["id"]
+
+        # Rename without sending tags or is_duplicate_transaction
+        response = test_client.put(
+            f"/api/events/{event_id}",
+            json={"name": "Renamed Event", "line_items": line_item_ids},
+            headers={"Authorization": "Bearer " + jwt_token},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert data["name"] == "Renamed Event"
+        assert data["tags"] == ["vacation"]
+        assert data["is_duplicate_transaction"] is True
+
     def test_event_line_items_returns_associated_line_items(
         self,
         test_client,

--- a/server/tests/test_models.py
+++ b/server/tests/test_models.py
@@ -200,8 +200,8 @@ def test_event_total_amount_sums_all_linked_line_items(db_session, common_fixtur
     assert event.total_amount == expected_total
 
 
-def test_duplicate_event_uses_first_line_item_amount_only(db_session, common_fixtures):
-    """Duplicate event uses only the first line item amount"""
+def test_duplicate_event_uses_minimum_line_item_amount_only(db_session, common_fixtures):
+    """Duplicate event uses only the minimum line item amount"""
     category = common_fixtures["category"]
     payment_method = common_fixtures["payment_method"]
 
@@ -217,7 +217,7 @@ def test_duplicate_event_uses_first_line_item_amount_only(db_session, common_fix
     db_session.commit()
 
     # Add two line items with different amounts (each with its own transaction)
-    amounts = [Decimal("100.00"), Decimal("100.00")]
+    amounts = [Decimal("100.01"), Decimal("100.00")]
     for i, amount in enumerate(amounts):
         transaction = Transaction(
             id=generate_id("txn"),
@@ -246,9 +246,9 @@ def test_duplicate_event_uses_first_line_item_amount_only(db_session, common_fix
     db_session.commit()
     db_session.refresh(event)
 
-    # With is_duplicate=True, should use first item only
+    # With is_duplicate=True, should use the minimum line item amount only
     assert event.total_amount == Decimal("100.00")
-    # Not the sum of both (200.00)
+    # Not the sum of both (200.01)
     assert event.total_amount != sum(amounts)
 
 

--- a/server/tests/test_splitwise.py
+++ b/server/tests/test_splitwise.py
@@ -271,7 +271,7 @@ class TestSplitwiseFunctions:
             refresh_splitwise()
 
             # Verify getExpenses was called with correct parameters
-            mock_splitwise_client.getExpenses.assert_called_once_with(limit=1000, dated_after="2022-08-03T00:00:00Z")
+            mock_splitwise_client.getExpenses.assert_called_once_with(limit=1000, offset=0, dated_after="2022-08-03T00:00:00Z")
 
     def test_deleted_expenses_are_filtered_out(
         self, flask_app, mock_splitwise_expense, mock_splitwise_expense_deleted, mocker
@@ -326,6 +326,151 @@ class TestSplitwiseFunctions:
                 assert line_item.payment_method_id is not None
                 assert line_item.description == "Test expense"
                 assert line_item.amount == 50.0
+
+    def test_edited_expense_updates_unevented_line_item_on_reimport(self, flask_app, mock_splitwise_expense_dict, mocker):
+        """Re-importing an edited expense updates the transaction and its un-evented line item"""
+        with flask_app.app_context():
+            from models.database import SessionLocal
+            from models.sql_models import LineItem, Transaction
+            from utils.pg_bulk_ops import bulk_upsert_transactions
+
+            with SessionLocal.begin() as db:
+                bulk_upsert_transactions(db, [mock_splitwise_expense_dict], source="splitwise_api")
+            splitwise_to_line_items()
+
+            # The expense amount is edited upstream and re-imported
+            edited = {
+                **mock_splitwise_expense_dict,
+                "users": [
+                    {"first_name": USER_FIRST_NAME, "net_balance": -75.0},
+                    {"first_name": "John Doe", "net_balance": 75.0},
+                ],
+            }
+            with SessionLocal.begin() as db:
+                bulk_upsert_transactions(db, [edited], source="splitwise_api")
+            splitwise_to_line_items()
+
+            with SessionLocal.begin() as db:
+                transaction = db.query(Transaction).filter_by(source="splitwise_api", source_id="expense_1").one()
+                assert transaction.source_data["users"][0]["net_balance"] == -75.0
+                line_items = db.query(LineItem).all()
+                assert len(line_items) == 1
+                assert line_items[0].amount == 75.0
+
+    def test_edited_expense_does_not_touch_evented_line_item(self, flask_app, mock_splitwise_expense_dict, mocker):
+        """Re-importing an edited expense leaves line items already assigned to an event unchanged"""
+        with flask_app.app_context():
+            from models.database import SessionLocal
+            from models.sql_models import Category, Event, EventLineItem, LineItem
+            from utils.id_generator import generate_id
+            from utils.pg_bulk_ops import bulk_upsert_transactions
+
+            with SessionLocal.begin() as db:
+                bulk_upsert_transactions(db, [mock_splitwise_expense_dict], source="splitwise_api")
+            splitwise_to_line_items()
+
+            with SessionLocal.begin() as db:
+                line_item = db.query(LineItem).one()
+                category = db.query(Category).first()
+                event = Event(
+                    id=generate_id("evt"),
+                    date=line_item.date,
+                    description="Reviewed event",
+                    category_id=category.id,
+                )
+                db.add(event)
+                db.add(EventLineItem(id=generate_id("eli"), event_id=event.id, line_item_id=line_item.id))
+
+            edited = {
+                **mock_splitwise_expense_dict,
+                "users": [
+                    {"first_name": USER_FIRST_NAME, "net_balance": -75.0},
+                    {"first_name": "John Doe", "net_balance": 75.0},
+                ],
+            }
+            with SessionLocal.begin() as db:
+                bulk_upsert_transactions(db, [edited], source="splitwise_api")
+            splitwise_to_line_items()
+
+            with SessionLocal.begin() as db:
+                assert db.query(LineItem).one().amount == 50.0
+
+    def test_deleted_expense_removes_unevented_transaction_and_line_item(self, flask_app, mock_splitwise_expense_dict, mocker):
+        """An expense deleted upstream removes its transaction and un-evented line item"""
+        with flask_app.app_context():
+            from models.database import SessionLocal
+            from models.sql_models import LineItem, Transaction
+            from utils.pg_bulk_ops import bulk_upsert_transactions, delete_transactions_for_removed_sources
+
+            with SessionLocal.begin() as db:
+                bulk_upsert_transactions(db, [mock_splitwise_expense_dict], source="splitwise_api")
+            splitwise_to_line_items()
+
+            with SessionLocal.begin() as db:
+                deleted = delete_transactions_for_removed_sources(db, "splitwise_api", ["expense_1"])
+                assert deleted == 1
+
+            with SessionLocal.begin() as db:
+                assert db.query(Transaction).count() == 0
+                assert db.query(LineItem).count() == 0
+
+    def test_deleted_expense_keeps_evented_line_item(self, flask_app, mock_splitwise_expense_dict, mocker):
+        """An expense deleted upstream is kept when its line item belongs to an event"""
+        with flask_app.app_context():
+            from models.database import SessionLocal
+            from models.sql_models import Category, Event, EventLineItem, LineItem, Transaction
+            from utils.id_generator import generate_id
+            from utils.pg_bulk_ops import bulk_upsert_transactions, delete_transactions_for_removed_sources
+
+            with SessionLocal.begin() as db:
+                bulk_upsert_transactions(db, [mock_splitwise_expense_dict], source="splitwise_api")
+            splitwise_to_line_items()
+
+            with SessionLocal.begin() as db:
+                line_item = db.query(LineItem).one()
+                category = db.query(Category).first()
+                event = Event(
+                    id=generate_id("evt"),
+                    date=line_item.date,
+                    description="Reviewed event",
+                    category_id=category.id,
+                )
+                db.add(event)
+                db.add(EventLineItem(id=generate_id("eli"), event_id=event.id, line_item_id=line_item.id))
+
+            with SessionLocal.begin() as db:
+                deleted = delete_transactions_for_removed_sources(db, "splitwise_api", ["expense_1"])
+                assert deleted == 0
+
+            with SessionLocal.begin() as db:
+                assert db.query(Transaction).count() == 1
+                assert db.query(LineItem).count() == 1
+
+    def test_refresh_paginates_past_expense_limit(self, flask_app, mocker):
+        """Refresh keeps fetching pages until fewer than LIMIT expenses are returned"""
+        with flask_app.app_context():
+            from constants import LIMIT
+
+            mock_splitwise_client = mocker.patch("resources.splitwise.splitwise_client")
+            mock_bulk_upsert = mocker.patch("resources.splitwise.bulk_upsert_transactions")
+            mocker.patch("resources.splitwise.delete_transactions_for_removed_sources")
+
+            def make_expense(i):
+                expense = mocker.Mock()
+                expense.deleted_at = None
+                expense.id = f"expense_{i}"
+                return expense
+
+            first_page = [make_expense(i) for i in range(LIMIT)]
+            second_page = [make_expense(LIMIT)]
+            mock_splitwise_client.getExpenses.side_effect = [first_page, second_page]
+
+            refresh_splitwise()
+
+            assert mock_splitwise_client.getExpenses.call_count == 2
+            assert mock_splitwise_client.getExpenses.call_args_list[1].kwargs["offset"] == LIMIT
+            # All expenses from both pages are upserted
+            assert len(mock_bulk_upsert.call_args[0][1]) == LIMIT + 1
 
     def test_expenses_with_ignored_parties_are_skipped(self, flask_app, mocker):
         """Expenses where responsible party is in ignore list are skipped"""

--- a/server/utils/pg_bulk_ops.py
+++ b/server/utils/pg_bulk_ops.py
@@ -75,7 +75,7 @@ def bulk_upsert_transactions(db_session, transactions_source_data: List[Any], so
             logger.warning(f"Skipping transaction without id: {txn_dict}")
             continue
 
-        source_ids.append((source, source_id))
+        source_ids.append(source_id)
         transaction_dicts.append(txn_dict)
 
     if not transaction_dicts:
@@ -84,13 +84,13 @@ def bulk_upsert_transactions(db_session, transactions_source_data: List[Any], so
     existing_by_source_id = {
         txn.source_id: txn
         for txn in db_session.query(Transaction)
-        .filter(Transaction.source == source, Transaction.source_id.in_([sid for _, sid in source_ids]))
+        .filter(Transaction.source == source, Transaction.source_id.in_(source_ids))
         .all()
     }
 
     bulk_inserts = []
     updated_count = 0
-    for txn_dict, (_, source_id) in zip(transaction_dicts, source_ids):
+    for txn_dict, source_id in zip(transaction_dicts, source_ids):
         transaction_date = get_transaction_date(txn_dict, source)
         source_data = _normalize_source_data({k: v for k, v in txn_dict.items() if k != "id"})
 

--- a/server/utils/pg_bulk_ops.py
+++ b/server/utils/pg_bulk_ops.py
@@ -5,6 +5,7 @@ Shared bulk write functions for efficiently upserting transactions and line item
 to PostgreSQL during the dual-write period.
 """
 
+import json
 import logging
 from datetime import UTC, datetime
 from decimal import Decimal
@@ -12,7 +13,7 @@ from typing import Any, Dict, List, Optional
 
 from helpers import iso_8601_to_posix, to_dict_robust
 from models.database import SessionLocal
-from models.sql_models import BankAccount, Category, LineItem, PaymentMethod, Transaction, User
+from models.sql_models import BankAccount, Category, EventLineItem, LineItem, PaymentMethod, Transaction, User
 from utils.id_generator import generate_id
 
 logger = logging.getLogger(__name__)
@@ -35,9 +36,18 @@ def get_transaction_date(transaction: Dict[str, Any], source: str) -> datetime:
         return datetime.now(UTC)
 
 
+def _normalize_source_data(source_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Round-trip through JSON so comparisons against stored JSON columns are type-stable."""
+    return json.loads(json.dumps(source_data, default=str))
+
+
 def bulk_upsert_transactions(db_session, transactions_source_data: List[Any], source: str) -> int:
     """
     Bulk upsert transactions to PostgreSQL.
+
+    Inserts new transactions and updates source_data on existing ones when the
+    external record changed (e.g. an edited Splitwise amount), so re-imports
+    propagate upstream edits.
 
     Args:
         db_session: SQLAlchemy session
@@ -45,7 +55,7 @@ def bulk_upsert_transactions(db_session, transactions_source_data: List[Any], so
         source: Transaction source type (venmo, splitwise, stripe, cash)
 
     Returns:
-        Count of inserted transactions
+        Count of inserted and updated transactions
     """
     if not transactions_source_data:
         return 0
@@ -71,23 +81,26 @@ def bulk_upsert_transactions(db_session, transactions_source_data: List[Any], so
     if not transaction_dicts:
         return 0
 
-    existing_query = db_session.query(Transaction.source, Transaction.source_id).filter(Transaction.source == source)
-    if source_ids:
-        existing_pairs = set(
-            (row.source, row.source_id)
-            for row in existing_query.filter(Transaction.source_id.in_([sid for _, sid in source_ids])).all()
-        )
-    else:
-        existing_pairs = set()
+    existing_by_source_id = {
+        txn.source_id: txn
+        for txn in db_session.query(Transaction)
+        .filter(Transaction.source == source, Transaction.source_id.in_([sid for _, sid in source_ids]))
+        .all()
+    }
 
     bulk_inserts = []
-    for txn_dict, (src, source_id) in zip(transaction_dicts, source_ids):
-        if (src, source_id) in existing_pairs:
-            continue
-
+    updated_count = 0
+    for txn_dict, (_, source_id) in zip(transaction_dicts, source_ids):
         transaction_date = get_transaction_date(txn_dict, source)
+        source_data = _normalize_source_data({k: v for k, v in txn_dict.items() if k != "id"})
 
-        source_data = {k: v for k, v in txn_dict.items() if k != "id"}
+        existing = existing_by_source_id.get(source_id)
+        if existing:
+            if existing.source_data != source_data:
+                existing.source_data = source_data
+                existing.transaction_date = transaction_date
+                updated_count += 1
+            continue
 
         bulk_inserts.append(
             {
@@ -102,9 +115,10 @@ def bulk_upsert_transactions(db_session, transactions_source_data: List[Any], so
     if bulk_inserts:
         db_session.bulk_insert_mappings(Transaction, bulk_inserts)
         logger.info(f"Bulk inserted {len(bulk_inserts)} {source} transactions to PostgreSQL")
-        return len(bulk_inserts)
+    if updated_count:
+        logger.info(f"Updated {updated_count} changed {source} transactions in PostgreSQL")
 
-    return 0
+    return len(bulk_inserts) + updated_count
 
 
 def _convert_line_item_to_dict(li: Any) -> Optional[Dict[str, Any]]:
@@ -131,36 +145,70 @@ def _convert_line_item_to_dict(li: Any) -> Optional[Dict[str, Any]]:
         return None
 
 
+def _parse_line_item_date(date_value: Any) -> datetime:
+    if isinstance(date_value, (int, float)):
+        return datetime.fromtimestamp(float(date_value), UTC)
+    logger.warning(f"Unexpected date type: {type(date_value)}, using current time")
+    return datetime.now(UTC)
+
+
+def _parse_line_item_amount(amount_value: Any) -> Decimal:
+    try:
+        return Decimal(str(amount_value))
+    except (ValueError, TypeError):
+        logger.warning(f"Invalid amount: {amount_value}, using 0")
+        return Decimal("0.00")
+
+
 def _build_line_item_insert_mapping(
     li_dict: Dict[str, Any],
     transaction_id: str,
     payment_method_id: str,
 ) -> Dict[str, Any]:
     """Build bulk insert mapping for a single line item."""
-    date_value = li_dict.get("date", 0)
-    if isinstance(date_value, (int, float)):
-        li_date = datetime.fromtimestamp(float(date_value), UTC)
-    else:
-        logger.warning(f"Unexpected date type: {type(date_value)}, using current time")
-        li_date = datetime.now(UTC)
-
-    amount_value = li_dict.get("amount", 0)
-    try:
-        li_amount = Decimal(str(amount_value))
-    except (ValueError, TypeError):
-        logger.warning(f"Invalid amount: {amount_value}, using 0")
-        li_amount = Decimal("0.00")
-
     return {
         "id": generate_id("li"),
         "transaction_id": transaction_id,
-        "date": li_date,
-        "amount": li_amount,
+        "date": _parse_line_item_date(li_dict.get("date", 0)),
+        "amount": _parse_line_item_amount(li_dict.get("amount", 0)),
         "description": li_dict.get("description", ""),
         "payment_method_id": payment_method_id,
         "responsible_party": li_dict.get("responsible_party", ""),
         "notes": li_dict.get("notes"),
     }
+
+
+def _dates_equal(a: Optional[datetime], b: Optional[datetime]) -> bool:
+    """Compare datetimes treating naive values (e.g. from SQLite) as UTC."""
+    if a is None or b is None:
+        return a == b
+    if a.tzinfo is None:
+        a = a.replace(tzinfo=UTC)
+    if b.tzinfo is None:
+        b = b.replace(tzinfo=UTC)
+    return a == b
+
+
+def _update_line_item_if_changed(line_item: LineItem, li_dict: Dict[str, Any]) -> bool:
+    """Apply external edits to an existing line item. Returns True if anything changed."""
+    new_date = _parse_line_item_date(li_dict.get("date", 0))
+    new_amount = _parse_line_item_amount(li_dict.get("amount", 0))
+    new_description = li_dict.get("description", "")
+    new_responsible_party = li_dict.get("responsible_party", "")
+
+    if (
+        line_item.amount == new_amount
+        and line_item.description == new_description
+        and (line_item.responsible_party or "") == new_responsible_party
+        and _dates_equal(line_item.date, new_date)
+    ):
+        return False
+
+    line_item.date = new_date
+    line_item.amount = new_amount
+    line_item.description = new_description
+    line_item.responsible_party = new_responsible_party
+    return True
 
 
 def bulk_upsert_line_items(db_session, line_items_data: List[Any], source: str) -> int:
@@ -228,25 +276,36 @@ def bulk_upsert_line_items(db_session, line_items_data: List[Any], source: str) 
     if not line_item_dicts:
         return 0
 
-    # Prevent duplicates: Skip line items for transactions that already have them.
-    # This allows safe re-importing of API data without creating duplicate line items.
-    existing_source_ids = set()
+    # Find line items that already exist for these transactions so re-imports
+    # update them instead of creating duplicates.
+    existing_line_items_by_source_id: Dict[str, LineItem] = {}
+    evented_line_item_ids: set = set()
     if source_ids_to_check:
-        # Find line items that already exist for these transactions
-        transactions_with_items = (
-            db_session.query(Transaction.source_id)
-            .join(LineItem, Transaction.id == LineItem.transaction_id)
+        rows = (
+            db_session.query(LineItem, Transaction.source_id)
+            .join(Transaction, Transaction.id == LineItem.transaction_id)
             .filter(Transaction.source == source, Transaction.source_id.in_(source_ids_to_check))
             .all()
         )
-        existing_source_ids = {row[0] for row in transactions_with_items}
+        existing_line_items_by_source_id = {row[1]: row[0] for row in rows}
+        if existing_line_items_by_source_id:
+            evented_line_item_ids = {
+                row[0]
+                for row in db_session.query(EventLineItem.line_item_id)
+                .filter(EventLineItem.line_item_id.in_([li.id for li in existing_line_items_by_source_id.values()]))
+                .all()
+            }
 
     bulk_inserts = []
+    updated_count = 0
     for li_dict in line_item_dicts:
         source_id = li_dict.get("source_id", "")
 
-        # Skip if this transaction already has a line item
-        if source_id and source_id in existing_source_ids:
+        existing_li = existing_line_items_by_source_id.get(source_id) if source_id else None
+        if existing_li:
+            # Propagate external edits, but never touch line items already reviewed into an event
+            if existing_li.id not in evented_line_item_ids:
+                updated_count += _update_line_item_if_changed(existing_li, li_dict)
             continue
 
         if not source_id:
@@ -276,9 +335,58 @@ def bulk_upsert_line_items(db_session, line_items_data: List[Any], source: str) 
     if bulk_inserts:
         db_session.bulk_insert_mappings(LineItem, bulk_inserts)
         logger.info(f"Bulk inserted {len(bulk_inserts)} {source} line items to PostgreSQL")
-        return len(bulk_inserts)
+    if updated_count:
+        logger.info(f"Updated {updated_count} changed {source} line items in PostgreSQL")
 
-    return 0
+    return len(bulk_inserts) + updated_count
+
+
+def delete_transactions_for_removed_sources(db_session, source: str, source_ids: List[str]) -> int:
+    """
+    Delete transactions (and their line items) whose source records were deleted upstream.
+
+    Transactions whose line item has already been reviewed into an event are kept
+    and logged, so upstream deletions never silently alter events.
+
+    Returns:
+        Count of deleted transactions
+    """
+    if not source_ids:
+        return 0
+
+    transactions = (
+        db_session.query(Transaction).filter(Transaction.source == source, Transaction.source_id.in_(source_ids)).all()
+    )
+    if not transactions:
+        return 0
+
+    line_items = db_session.query(LineItem).filter(LineItem.transaction_id.in_([txn.id for txn in transactions])).all()
+    line_item_by_transaction_id = {li.transaction_id: li for li in line_items}
+    evented_line_item_ids = (
+        {
+            row[0]
+            for row in db_session.query(EventLineItem.line_item_id)
+            .filter(EventLineItem.line_item_id.in_([li.id for li in line_items]))
+            .all()
+        }
+        if line_items
+        else set()
+    )
+
+    deleted_count = 0
+    for txn in transactions:
+        line_item = line_item_by_transaction_id.get(txn.id)
+        if line_item and line_item.id in evented_line_item_ids:
+            logger.warning(f"Keeping {source} transaction {txn.source_id} deleted upstream: its line item belongs to an event")
+            continue
+        if line_item:
+            db_session.delete(line_item)
+        db_session.delete(txn)
+        deleted_count += 1
+
+    if deleted_count:
+        logger.info(f"Deleted {deleted_count} {source} transactions removed upstream")
+    return deleted_count
 
 
 def bulk_upsert_bank_accounts(db_session, accounts_data: List[Any]) -> int:


### PR DESCRIPTION
## Summary
This PR adds support for propagating upstream edits to transactions and line items during re-imports, and safely deleting transactions whose source records were removed. Previously, re-imports would skip existing records entirely, preventing external edits from being reflected in the app.

## Key Changes

**Transaction Updates**
- Modified `bulk_upsert_transactions()` to detect when source data has changed and update existing transactions with new `source_data` and `transaction_date`
- Added `_normalize_source_data()` helper to JSON round-trip source data for type-stable comparisons against stored JSON columns
- Updated return value to count both inserts and updates

**Line Item Updates**
- Modified `bulk_upsert_line_items()` to update existing line items when amounts, dates, descriptions, or responsible parties change
- Added `_parse_line_item_date()` and `_parse_line_item_amount()` helpers to extract parsing logic
- Added `_dates_equal()` helper to safely compare datetimes with mixed timezone awareness (handles naive values from SQLite)
- Added `_update_line_item_if_changed()` to apply external edits while preserving line items already assigned to events
- Updated return value to count both inserts and updates

**Transaction Deletion**
- Added new `delete_transactions_for_removed_sources()` function to safely remove transactions whose source records were deleted upstream
- Protects line items already reviewed into events from deletion (logs warning instead)
- Integrated into Splitwise refresh to handle deleted expenses

**Splitwise Integration**
- Updated `refresh_splitwise()` to paginate through all expenses using `offset` parameter (was previously capped at LIMIT)
- Separated deleted expenses and calls `delete_transactions_for_removed_sources()` to clean them up
- Updated logging to report deleted upstream expenses

**Event Updates**
- Fixed `update_event_api()` to preserve existing `tags` and `is_duplicate_transaction` values when not provided in request
- Updated duplicate event amount calculation to use `min()` instead of first line item (deterministic and consistent with DAO query)
- Updated `Event.total_amount` property to use `min()` for duplicate events

**Tests**
- Added comprehensive tests for edited expense re-imports (both evented and unevented line items)
- Added tests for deleted expense handling (both evented and unevented)
- Added pagination test for Splitwise refresh
- Added test for event update preserving omitted fields
- Updated existing test expectations for pagination offset parameter

## Implementation Details

The key insight is that line items already assigned to events (via `EventLineItem` junction table) should never be modified or deleted, since they represent user-reviewed categorizations. The code checks for this relationship before applying updates or deletions, logging warnings when upstream changes conflict with reviewed events.

Source data normalization through JSON round-trip ensures that comparisons work correctly regardless of how the data was originally parsed (e.g., numeric strings vs actual numbers).

https://claude.ai/code/session_01XXHLwXdCApwP6BJgYQCr8q