### PR TITLE
Improve error handling in API endpoints

### DIFF
--- a/server/resources/event.py
+++ b/server/resources/event.py
@@ -208,4 +208,4 @@ def get_line_items_for_event_api(
         return jsonify({"data": line_items}), 200
     except Exception as e:
         logger.error(f"Error retrieving line items for event {event_id}: {e}")
-        return jsonify(error=str(e)), 500
+        return jsonify({"error": "Request failed"}), 500

--- a/server/resources/stripe.py
+++ b/server/resources/stripe.py
@@ -162,7 +162,8 @@ def create_fc_session_api(
 
         return jsonify({"clientSecret": session["client_secret"]}), 200
     except Exception as e:
-        return jsonify(error=str(e)), 500
+        logger.error(f"Error creating financial connections session: {e}")
+        return jsonify({"error": "Request failed"}), 500
 
 
 @stripe_blueprint.route("/api/create_accounts", methods=["POST"])
@@ -190,7 +191,8 @@ def get_accounts_api(session_id: str) -> tuple[Response, int]:
 
         return jsonify({"accounts": accounts}), 200
     except Exception as e:
-        return jsonify(error=str(e)), 500
+        logger.error(f"Error retrieving accounts for session {session_id}: {e}")
+        return jsonify({"error": "Request failed"}), 500
 
 
 @stripe_blueprint.route("/api/accounts_and_balances")
@@ -242,7 +244,8 @@ def subscribe_to_account_api() -> tuple[Response, int]:
         refresh_status: str = response.get("transaction_refresh", {}).get("status", "unknown")
         return jsonify(str(refresh_status)), 200
     except Exception as e:
-        return jsonify(error=str(e)), 500
+        logger.error(f"Error subscribing to account: {e}")
+        return jsonify({"error": "Request failed"}), 500
 
 
 def refresh_account(account_id: str) -> None:
@@ -261,7 +264,8 @@ def refresh_account_api(account_id: str) -> tuple[Response, int]:
         refresh_account(account_id)
         return jsonify({"data": "success"}), 200
     except Exception as e:
-        return jsonify(error=str(e)), 500
+        logger.error(f"Error refreshing account {account_id}: {e}")
+        return jsonify({"error": "Request failed"}), 500
 
 
 @stripe_blueprint.route("/api/relink_account/<account_id>", methods=["POST"])
@@ -277,7 +281,8 @@ def relink_account_api(account_id: str) -> tuple[Response, int]:
         create_fc_session_response = create_fc_session_api(account["authorization"])
         return jsonify(create_fc_session_response[0].json), 200
     except Exception as e:
-        return jsonify(error=str(e)), 500
+        logger.error(f"Error relinking account {account_id}: {e}")
+        return jsonify({"error": "Request failed"}), 500
 
 
 def refresh_transactions(account_id: str) -> None:
@@ -328,7 +333,8 @@ def refresh_transactions_api(account_id: str) -> tuple[Response, int]:
         refresh_transactions(account_id)
         return jsonify("Refreshed Stripe Connection for Given Account"), 200
     except Exception as e:
-        return jsonify(error=str(e)), 500
+        logger.error(f"Error refreshing transactions for account {account_id}: {e}")
+        return jsonify({"error": "Request failed"}), 500
 
 
 def refresh_stripe() -> None:


### PR DESCRIPTION
## Summary
Standardized error handling across API endpoints to improve security and user experience by logging detailed errors server-side while returning generic error messages to clients.

## Changes
- Updated 6 API endpoints in `stripe.py` to log detailed error information and return generic error responses
- Updated 1 API endpoint in `event.py` to use consistent error response format
- Changed error response format from `jsonify(error=str(e))` to `jsonify({"error": "Request failed"})` for consistency
- Added server-side logging via `logger.error()` for all exceptions with contextual information (session IDs, account IDs, etc.)

## Implementation Details
- Error responses now use a consistent JSON structure: `{"error": "Request failed"}`
- Detailed error messages are logged server-side with context about which operation failed
- This prevents sensitive error details from leaking to clients while maintaining debuggability for developers
- Affected endpoints: `create_fc_session_api`, `get_accounts_api`, `subscribe_to_account_api`, `refresh_account_api`, `relink_account_api`, `refresh_transactions_api`, and `get_line_items_for_event_api`

https://claude.ai/code/session_019D4WBpKvs8gu5CxVfqwfJg