### PR TITLE
Add pagination support to line items and events APIs

### DIFF
--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -23,7 +23,7 @@ export const queryKeys = {
 };
 
 // Query Hooks
-export function useEvents(startTime?: number, endTime?: number): UseQueryResult<EventInterface[]> {
+export function useEvents(startTime?: number, endTime?: number, limit?: number, offset?: number): UseQueryResult<EventInterface[]> {
   return useQuery({
     queryKey: queryKeys.events(startTime, endTime),
     queryFn: async () => {
@@ -31,6 +31,8 @@ export function useEvents(startTime?: number, endTime?: number): UseQueryResult<
         params: {
           start_time: startTime,
           end_time: endTime,
+          ...(limit !== undefined && { limit }),
+          ...(offset !== undefined && offset > 0 && { offset }),
         },
       });
       return response.data.data as EventInterface[];
@@ -39,17 +41,23 @@ export function useEvents(startTime?: number, endTime?: number): UseQueryResult<
   });
 }
 
-export function useLineItems(params?: { onlyLineItemsToReview?: boolean; paymentMethod?: string; enabled?: boolean }): UseQueryResult<LineItemInterface[]> {
+export function useLineItems(params?: { onlyLineItemsToReview?: boolean; paymentMethod?: string; enabled?: boolean; limit?: number; offset?: number }): UseQueryResult<LineItemInterface[]> {
   return useQuery({
     queryKey: queryKeys.lineItems(params ? { onlyLineItemsToReview: params.onlyLineItemsToReview, paymentMethod: params.paymentMethod } : undefined),
     queryFn: async () => {
-      const queryParams: Record<string, string | boolean> = {};
+      const queryParams: Record<string, string | boolean | number> = {};
 
       if (params?.onlyLineItemsToReview) {
         queryParams.only_line_items_to_review = true;
       }
       if (params?.paymentMethod && params.paymentMethod !== 'All') {
         queryParams.payment_method = params.paymentMethod;
+      }
+      if (params?.limit !== undefined) {
+        queryParams.limit = params.limit;
+      }
+      if (params?.offset !== undefined && params.offset > 0) {
+        queryParams.offset = params.offset;
       }
 
       const response = await axiosInstance.get('api/line_items', { params: queryParams });

--- a/server/dao.py
+++ b/server/dao.py
@@ -190,7 +190,11 @@ def get_line_item_amounts(line_item_ids: list[str]) -> List[Dict[str, Any]]:
         return [{"id": row.id, "date": serialize_datetime(row.date), "amount": float(row.amount or 0.0)} for row in rows]
 
 
-def get_all_line_items(filters: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def get_all_line_items(
+    filters: Optional[Dict[str, Any]],
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
     """Get line items from PostgreSQL"""
     from models.database import SessionLocal
     from models.sql_models import Event, LineItem, PaymentMethod
@@ -222,6 +226,10 @@ def get_all_line_items(filters: Optional[Dict[str, Any]]) -> List[Dict[str, Any]
                         query = query.outerjoin(LineItem.events).filter(Event.id.is_(None))
 
         query = query.order_by(LineItem.date.desc())
+        if offset:
+            query = query.offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
         line_items = query.all()
         return [serialize_line_item(li) for li in line_items]
 
@@ -252,7 +260,11 @@ def get_user_by_id(id: str) -> Optional[Dict[str, Any]]:
         return serialize_user(user) if user else None
 
 
-def get_all_events(filters: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
+def get_all_events(
+    filters: Optional[Dict[str, Any]],
+    limit: Optional[int] = None,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
     """Get events from PostgreSQL"""
     from datetime import datetime
 
@@ -278,7 +290,12 @@ def get_all_events(filters: Optional[Dict[str, Any]]) -> List[Dict[str, Any]]:
                 if "$lte" in date_filter:
                     query = query.filter(Event.date <= datetime.fromtimestamp(date_filter["$lte"], UTC))
 
-        events = query.order_by(Event.date.desc()).all()
+        query = query.order_by(Event.date.desc())
+        if offset:
+            query = query.offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
+        events = query.all()
         return [serialize_event(event) for event in events]
 
 

--- a/server/resources/event.py
+++ b/server/resources/event.py
@@ -28,13 +28,17 @@ def all_events_api() -> tuple[Response, int]:
     Filters:
         - Start Time
         - End Time
+        - Limit (optional)
+        - Offset (optional)
     """
     filters: Dict[str, Any] = {}
     logger.info(f"Current User: {get_current_user()['email']}")
     start_time: float = float(request.args.get("start_time", SMALLEST_EPOCH_TIME))
     end_time: float = float(request.args.get("end_time", LARGEST_EPOCH_TIME))
     filters["date"] = {"$gte": start_time, "$lte": end_time}
-    events: List[Dict[str, Any]] = get_all_events(filters)
+    limit: Optional[int] = int(request.args["limit"]) if "limit" in request.args else None
+    offset: int = int(request.args.get("offset", 0))
+    events: List[Dict[str, Any]] = get_all_events(filters, limit, offset)
     events_total: float = sum(event["amount"] for event in events)
     logger.info(f"Retrieved {len(events)} events (total: ${events_total:.2f})")
     return jsonify({"total": events_total, "data": events}), 200

--- a/server/resources/line_item.py
+++ b/server/resources/line_item.py
@@ -81,10 +81,14 @@ def all_line_items_api() -> tuple[Response, int]:
     Get All Line Items
         - Payment Method (optional)
         - Only Line Items To Review (optional)
+        - Limit (optional)
+        - Offset (optional)
     """
     only_line_items_to_review: Optional[bool] = str_to_bool(request.args.get("only_line_items_to_review"))
     payment_method: Optional[str] = request.args.get("payment_method")
-    line_items: List[Dict[str, Any]] = all_line_items(only_line_items_to_review, payment_method)
+    limit: Optional[int] = int(request.args["limit"]) if "limit" in request.args else None
+    offset: int = int(request.args.get("offset", 0))
+    line_items: List[Dict[str, Any]] = all_line_items(only_line_items_to_review, payment_method, limit, offset)
     line_items_total: float = sum(line_item["amount"] for line_item in line_items)
     logger.info(f"Retrieved {len(line_items)} line items (total: ${line_items_total:.2f})")
     return jsonify({"total": line_items_total, "data": line_items}), 200
@@ -93,6 +97,8 @@ def all_line_items_api() -> tuple[Response, int]:
 def all_line_items(
     only_line_items_to_review: Optional[bool] = None,
     payment_method: Optional[str] = None,
+    limit: Optional[int] = None,
+    offset: int = 0,
 ) -> List[Dict[str, Any]]:
     filters: Dict[str, Any] = {}
     if payment_method not in ["All", None]:
@@ -102,7 +108,7 @@ def all_line_items(
         # Only get line items that don't have an event associated
         filters["event_id"] = {"$exists": False}
 
-    line_items: List[Dict[str, Any]] = get_all_line_items(filters)
+    line_items: List[Dict[str, Any]] = get_all_line_items(filters, limit, offset)
     line_items = sort_by_date_description(line_items)
     return line_items
 

--- a/server/tests/test_event.py
+++ b/server/tests/test_event.py
@@ -881,6 +881,88 @@ class TestEventAPI:
         data = response.get_json()
         assert data["error"] == "None of the provided line item IDs exist"
 
+    def test_limit_via_api_restricts_returned_events(
+        self,
+        test_client,
+        jwt_token,
+        flask_app,
+        create_line_item_via_manual,
+        create_event_via_api,
+    ):
+        """GET /api/events?limit=N returns at most N events"""
+        for i in range(4):
+            create_line_item_via_manual(date="2009-02-13", person=f"Person{i}", description=f"Transaction {i}", amount=10)
+
+        with flask_app.app_context():
+            from dao import get_all_line_items
+
+            line_item_ids = [item["id"] for item in get_all_line_items(None)]
+
+        for li_id in line_item_ids:
+            create_event_via_api(
+                {
+                    "name": f"Event {li_id}",
+                    "category": "Dining",
+                    "date": "2009-02-13",
+                    "line_items": [li_id],
+                    "tags": [],
+                    "is_duplicate_transaction": False,
+                }
+            )
+
+        response = test_client.get(
+            "/api/events?limit=2",
+            headers={"Authorization": "Bearer " + jwt_token},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["data"]) == 2
+
+    def test_offset_via_api_skips_leading_events(
+        self,
+        test_client,
+        jwt_token,
+        flask_app,
+        create_line_item_via_manual,
+        create_event_via_api,
+    ):
+        """GET /api/events?offset=N skips the first N events"""
+        for i in range(4):
+            create_line_item_via_manual(date="2009-02-13", person=f"Person{i}", description=f"Transaction {i}", amount=10)
+
+        with flask_app.app_context():
+            from dao import get_all_line_items
+
+            line_item_ids = [item["id"] for item in get_all_line_items(None)]
+
+        for li_id in line_item_ids:
+            create_event_via_api(
+                {
+                    "name": f"Event {li_id}",
+                    "category": "Dining",
+                    "date": "2009-02-13",
+                    "line_items": [li_id],
+                    "tags": [],
+                    "is_duplicate_transaction": False,
+                }
+            )
+
+        full_response = test_client.get(
+            "/api/events",
+            headers={"Authorization": "Bearer " + jwt_token},
+        )
+        paged_response = test_client.get(
+            "/api/events?offset=2",
+            headers={"Authorization": "Bearer " + jwt_token},
+        )
+
+        assert paged_response.status_code == 200
+        full_data = full_response.get_json()["data"]
+        paged_data = paged_response.get_json()["data"]
+        assert len(paged_data) == 2
+        assert paged_data[0]["id"] == full_data[2]["id"]
+
     def test_event_update_with_nonexistent_line_item_ids_returns_400(
         self, test_client, jwt_token, flask_app, create_line_item_via_manual, create_event_via_api
     ):

--- a/server/tests/test_line_item.py
+++ b/server/tests/test_line_item.py
@@ -532,3 +532,124 @@ class TestLineItemFunctions:
             result = all_line_items(payment_method="All")
 
             assert len(result) == 2  # Should return all items, same as no filter
+
+    def test_limit_restricts_number_of_returned_items(self, flask_app, pg_session):
+        """Limit parameter restricts the number of line items returned"""
+        from tests.test_helpers import setup_test_line_item
+
+        with flask_app.app_context():
+            # Use distinct days so DB date order matches final sorted order
+            for i in range(5):
+                setup_test_line_item(
+                    pg_session,
+                    {
+                        "id": f"line_item_{i}",
+                        "date": 1234567890 + i * 86400,
+                        "responsible_party": "John Doe",
+                        "payment_method": "Cash",
+                        "description": f"Transaction {i}",
+                        "amount": 10 * (i + 1),
+                    },
+                )
+            pg_session.commit()
+
+            result = all_line_items(limit=3)
+
+            assert len(result) == 3
+
+    def test_offset_skips_leading_items(self, flask_app, pg_session):
+        """Offset parameter skips the first N line items"""
+        from tests.test_helpers import setup_test_line_item
+
+        with flask_app.app_context():
+            # Use distinct days so DB date order matches final sorted order
+            for i in range(5):
+                setup_test_line_item(
+                    pg_session,
+                    {
+                        "id": f"line_item_{i}",
+                        "date": 1234567890 + i * 86400,
+                        "responsible_party": "John Doe",
+                        "payment_method": "Cash",
+                        "description": f"Transaction {i}",
+                        "amount": 10 * (i + 1),
+                    },
+                )
+            pg_session.commit()
+
+            all_result = all_line_items()
+            paged_result = all_line_items(offset=2)
+
+            assert len(paged_result) == 3
+            assert paged_result[0]["id"] == all_result[2]["id"]
+
+    def test_limit_and_offset_together_return_correct_page(self, flask_app, pg_session):
+        """Limit and offset together select a specific page of results"""
+        from tests.test_helpers import setup_test_line_item
+
+        with flask_app.app_context():
+            # Use distinct days so DB date order matches final sorted order
+            for i in range(5):
+                setup_test_line_item(
+                    pg_session,
+                    {
+                        "id": f"line_item_{i}",
+                        "date": 1234567890 + i * 86400,
+                        "responsible_party": "John Doe",
+                        "payment_method": "Cash",
+                        "description": f"Transaction {i}",
+                        "amount": 10 * (i + 1),
+                    },
+                )
+            pg_session.commit()
+
+            all_result = all_line_items()
+            page2 = all_line_items(limit=2, offset=2)
+
+            assert len(page2) == 2
+            assert page2[0]["id"] == all_result[2]["id"]
+            assert page2[1]["id"] == all_result[3]["id"]
+
+    def test_limit_via_api_restricts_returned_items(self, test_client, jwt_token, create_line_item_via_manual):
+        """GET /api/line_items?limit=N returns at most N line items"""
+        for i in range(4):
+            create_line_item_via_manual(
+                date="2009-02-13",
+                person="John Doe",
+                description=f"Transaction {i}",
+                amount=10,
+            )
+
+        response = test_client.get(
+            "/api/line_items?limit=2",
+            headers={"Authorization": "Bearer " + jwt_token},
+        )
+
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["data"]) == 2
+
+    def test_offset_via_api_skips_leading_items(self, test_client, jwt_token, create_line_item_via_manual):
+        """GET /api/line_items?offset=N skips the first N line items"""
+        for i in range(4):
+            create_line_item_via_manual(
+                date="2009-02-13",
+                person="John Doe",
+                description=f"Transaction {i}",
+                amount=10,
+            )
+
+        full_response = test_client.get(
+            "/api/line_items",
+            headers={"Authorization": "Bearer " + jwt_token},
+        )
+        paged_response = test_client.get(
+            "/api/line_items?offset=2",
+            headers={"Authorization": "Bearer " + jwt_token},
+        )
+
+        assert paged_response.status_code == 200
+        full_data = full_response.get_json()["data"]
+        paged_data = paged_response.get_json()["data"]
+        assert len(paged_data) == 2
+        assert paged_data[0]["id"] == full_data[2]["id"]


### PR DESCRIPTION
## Summary
Adds `limit` and `offset` query parameters to the line items and events APIs, enabling pagination of results. This allows clients to retrieve large datasets in manageable chunks.

## Key Changes

**Backend (Python/Flask)**
- Updated `get_all_line_items()` and `get_all_events()` in `dao.py` to accept optional `limit` and `offset` parameters
- Applied pagination at the database query level using SQLAlchemy's `.limit()` and `.offset()` methods
- Updated `/api/line_items` and `/api/events` endpoints to parse `limit` and `offset` query parameters and pass them to the DAO functions
- Updated docstrings to document the new pagination parameters

**Frontend (TypeScript/React)**
- Extended `useEvents()` hook to accept optional `limit` and `offset` parameters
- Extended `useLineItems()` hook to accept optional `limit` and `offset` parameters
- Both hooks conditionally include pagination parameters in API requests only when defined

**Tests**
- Added 5 new tests for line items pagination:
  - `test_limit_restricts_number_of_returned_items` - verifies limit parameter works
  - `test_offset_skips_leading_items` - verifies offset parameter works
  - `test_limit_and_offset_together_return_correct_page` - verifies combined pagination
  - `test_limit_via_api_restricts_returned_items` - API integration test for limit
  - `test_offset_via_api_skips_leading_items` - API integration test for offset
- Added 2 new tests for events pagination:
  - `test_limit_via_api_restricts_returned_events` - API integration test for limit
  - `test_offset_via_api_skips_leading_events` - API integration test for offset

## Implementation Details
- Pagination is applied after filtering and sorting, ensuring consistent results across pages
- The `offset` parameter defaults to 0 when not provided
- The `limit` parameter is optional (None means no limit)
- Frontend only includes pagination parameters in requests when they are explicitly provided and meaningful (offset > 0)

https://claude.ai/code/session_01DjbSr1zyr8y9FkniUYvL2G