### PR TITLE
Memoize filtered events and calculations in EventsPage

### DIFF
--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -5,7 +5,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import { CurrencyFormatter } from "@/utils/formatters";
 import { ChevronDown, ChevronUp, Filter } from "lucide-react";
 import { DateTime } from "luxon";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { NON_SPENDING_CATEGORIES } from "../components/charts/chart-utils";
 import CategoryFilter from "../components/CategoryFilter";
 import Event, { EventCard, EventInterface } from "../components/Event";
@@ -68,9 +68,18 @@ export default function EventsPage() {
         return sum;
     }
 
-    const cashFlowWithFilters = calculateCashFlowWithFilters(events);
-    const spending = calculateSpending(events);
-    const filteredEvents = events.filter(event => matchCategory(event) && matchTags(event));
+    const filteredEvents = useMemo(
+        () => events.filter(event => matchCategory(event) && matchTags(event)),
+        [events, category, tagFilter]
+    );
+    const spending = useMemo(
+        () => calculateSpending(events),
+        [events, category, tagFilter]
+    );
+    const cashFlowWithFilters = useMemo(
+        () => calculateCashFlowWithFilters(events),
+        [events, category, tagFilter]
+    );
 
     // Count active filters
     const activeFilterCount = [


### PR DESCRIPTION
## Summary
Optimized the EventsPage component by memoizing expensive calculations to prevent unnecessary re-renders and recalculations when component state changes.

## Changes
- Added `useMemo` import from React
- Wrapped `filteredEvents` calculation in `useMemo` with dependencies on `events`, `category`, and `tagFilter`
- Wrapped `spending` calculation in `useMemo` with dependencies on `events`, `category`, and `tagFilter`
- Wrapped `cashFlowWithFilters` calculation in `useMemo` with dependencies on `events`, `category`, and `tagFilter`

## Implementation Details
The three calculations (`filteredEvents`, `spending`, and `cashFlowWithFilters`) are now memoized to avoid recomputing them on every render. Each memoized value depends on `events`, `category`, and `tagFilter`, ensuring the calculations are only rerun when these dependencies actually change. This improves performance by preventing unnecessary filtering and aggregation operations during component re-renders.

https://claude.ai/code/session_01R3dyTdyYHKMpoGEu8WLcyD