### PR TITLE
Refactor get_all_line_items to use explicit parameters

### DIFF
--- a/server/dao.py
+++ b/server/dao.py
@@ -191,7 +191,9 @@ def get_line_item_amounts(line_item_ids: list[str]) -> List[Dict[str, Any]]:
 
 
 def get_all_line_items(
-    filters: Optional[Dict[str, Any]],
+    ids: Optional[List[str]] = None,
+    payment_method: Optional[str] = None,
+    only_unreviewed: bool = False,
     limit: Optional[int] = None,
     offset: int = 0,
 ) -> List[Dict[str, Any]]:
@@ -206,24 +208,12 @@ def get_all_line_items(
             joinedload(LineItem.transaction),
         )
 
-        if filters:
-            # Handle id: {$in: [...]} pattern (used in event creation)
-            if "id" in filters:
-                id_filter = filters["id"]
-                if isinstance(id_filter, dict) and "$in" in id_filter:
-                    ids = [str(id) for id in id_filter["$in"]]
-                    query = query.filter(LineItem.id.in_(ids))
-
-            if "payment_method" in filters and filters["payment_method"] not in [
-                "All",
-                None,
-            ]:
-                query = query.join(LineItem.payment_method).filter(PaymentMethod.name == filters["payment_method"])
-
-            if "event_id" in filters:
-                if isinstance(filters["event_id"], dict) and "$exists" in filters["event_id"]:
-                    if not filters["event_id"]["$exists"]:
-                        query = query.outerjoin(LineItem.events).filter(Event.id.is_(None))
+        if ids is not None:
+            query = query.filter(LineItem.id.in_(ids))
+        if payment_method and payment_method != "All":
+            query = query.join(LineItem.payment_method).filter(PaymentMethod.name == payment_method)
+        if only_unreviewed:
+            query = query.outerjoin(LineItem.events).filter(Event.id.is_(None))
 
         query = query.order_by(LineItem.date.desc())
         if offset:

--- a/server/resources/event.py
+++ b/server/resources/event.py
@@ -121,8 +121,7 @@ def update_event_api(event_id: str) -> tuple[Response, int]:
         logger.warning("Event update attempt with no line items")
         return jsonify({"error": "Event must have at least one line item"}), 400
 
-    filters: Dict[str, Any] = {"id": {"$in": update_data["line_items"]}}
-    line_items: List[Dict[str, Any]] = get_all_line_items(filters)
+    line_items: List[Dict[str, Any]] = get_all_line_items(ids=update_data["line_items"])
     if not line_items:
         logger.warning(f"Event update attempt for {event_id}: no valid line items found for provided IDs")
         return jsonify({"error": "None of the provided line item IDs exist"}), 400
@@ -206,8 +205,7 @@ def get_line_items_for_event_api(
         if event is None:
             logger.warning(f"Line items request for non-existent event: {event_id}")
             return jsonify({"error": "Event not found"}), 404
-        filters = {"id": {"$in": event["line_items"]}}
-        line_items: List[Dict[str, Any]] = get_all_line_items(filters)
+        line_items: List[Dict[str, Any]] = get_all_line_items(ids=event["line_items"])
         logger.info(f"Retrieved {len(line_items)} line items for event: {event_id}")
         return jsonify({"data": line_items}), 200
     except Exception as e:

--- a/server/resources/line_item.py
+++ b/server/resources/line_item.py
@@ -100,15 +100,12 @@ def all_line_items(
     limit: Optional[int] = None,
     offset: int = 0,
 ) -> List[Dict[str, Any]]:
-    filters: Dict[str, Any] = {}
-    if payment_method not in ["All", None]:
-        filters["payment_method"] = payment_method
-
-    if only_line_items_to_review:
-        # Only get line items that don't have an event associated
-        filters["event_id"] = {"$exists": False}
-
-    line_items: List[Dict[str, Any]] = get_all_line_items(filters, limit, offset)
+    line_items: List[Dict[str, Any]] = get_all_line_items(
+        payment_method=payment_method,
+        only_unreviewed=bool(only_line_items_to_review),
+        limit=limit,
+        offset=offset,
+    )
     line_items = sort_by_date_description(line_items)
     return line_items
 

--- a/server/tests/test_event.py
+++ b/server/tests/test_event.py
@@ -58,7 +58,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 2
 
@@ -114,7 +114,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             all_line_items_sorted = sorted(all_line_items, key=lambda x: x["date"])
             assert len(all_line_items_sorted) == 2
             line_item_feb13 = all_line_items_sorted[0]  # 2009-02-13, amount=100
@@ -172,7 +172,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 1
 
@@ -232,7 +232,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 2
 
@@ -310,7 +310,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 1
 
@@ -356,7 +356,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 1
 
@@ -409,7 +409,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 1
 
@@ -474,7 +474,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 2
 
@@ -557,7 +557,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
 
         # Create event via API
@@ -604,7 +604,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
 
         event_response = create_event_via_api(
@@ -659,7 +659,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 2
 
@@ -714,7 +714,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 1
 
@@ -896,7 +896,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            line_item_ids = [item["id"] for item in get_all_line_items(None)]
+            line_item_ids = [item["id"] for item in get_all_line_items()]
 
         for li_id in line_item_ids:
             create_event_via_api(
@@ -934,7 +934,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            line_item_ids = [item["id"] for item in get_all_line_items(None)]
+            line_item_ids = [item["id"] for item in get_all_line_items()]
 
         for li_id in line_item_ids:
             create_event_via_api(
@@ -972,7 +972,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_id = all_line_items[0]["id"]
 
         event = create_event_via_api(
@@ -1009,7 +1009,7 @@ class TestEventAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             line_item_ids = [item["id"] for item in all_line_items]
             assert len(line_item_ids) == 2
 

--- a/server/tests/test_line_item.py
+++ b/server/tests/test_line_item.py
@@ -177,7 +177,7 @@ class TestLineItemAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             all_line_items_sorted = sorted(all_line_items, key=lambda x: x["amount"])
             assert len(all_line_items_sorted) == 2
             line_item_100 = all_line_items_sorted[1]  # amount=100
@@ -221,7 +221,7 @@ class TestLineItemAPI:
         with flask_app.app_context():
             from dao import get_all_line_items
 
-            all_line_items = get_all_line_items(None)
+            all_line_items = get_all_line_items()
             assert len(all_line_items) == 1
             line_item_id = all_line_items[0]["id"]
 

--- a/server/tests/test_manual_transaction.py
+++ b/server/tests/test_manual_transaction.py
@@ -66,7 +66,7 @@ def test_manual_transaction_creates_line_item(test_client, jwt_token, flask_app)
 
     # Verify line item was created
     with flask_app.app_context():
-        line_items_db = get_all_line_items(None)
+        line_items_db = get_all_line_items()
         assert len(line_items_db) == 1
         item_in_db = line_items_db[0]
         assert item_in_db["id"].startswith("li_")
@@ -96,7 +96,7 @@ def test_manual_transaction_with_venmo_payment_method(test_client, jwt_token, fl
     assert response.status_code == 201
 
     with flask_app.app_context():
-        line_items_db = get_all_line_items(None)
+        line_items_db = get_all_line_items()
         assert len(line_items_db) == 1
         item_in_db = line_items_db[0]
         assert item_in_db["payment_method"] == "Venmo"
@@ -190,7 +190,7 @@ def test_delete_manual_transaction(test_client, jwt_token, flask_app):
 
     # Verify it exists
     with flask_app.app_context():
-        line_items_db = get_all_line_items(None)
+        line_items_db = get_all_line_items()
         assert len(line_items_db) == 1
 
     # Delete it
@@ -203,7 +203,7 @@ def test_delete_manual_transaction(test_client, jwt_token, flask_app):
 
     # Verify it's gone
     with flask_app.app_context():
-        line_items_db = get_all_line_items(None)
+        line_items_db = get_all_line_items()
         assert len(line_items_db) == 0
         manual_db = get_transactions("manual", None)
         assert len(manual_db) == 0
@@ -240,7 +240,7 @@ def test_cannot_delete_transaction_assigned_to_event(test_client, jwt_token, fla
 
     # Get the line item ID
     with flask_app.app_context():
-        line_items_db = get_all_line_items(None)
+        line_items_db = get_all_line_items()
         assert len(line_items_db) == 1
         line_item_id = line_items_db[0]["id"]
 
@@ -269,7 +269,7 @@ def test_cannot_delete_transaction_assigned_to_event(test_client, jwt_token, fla
 
     # Verify the transaction still exists
     with flask_app.app_context():
-        line_items_db = get_all_line_items(None)
+        line_items_db = get_all_line_items()
         assert len(line_items_db) == 1
 
 
@@ -301,7 +301,7 @@ def test_create_manual_transaction_creates_transaction_and_line_item(flask_app):
         assert manual_db[0]["amount"] == 50.0
 
         # Verify line item was stored
-        line_items_db = get_all_line_items(None)
+        line_items_db = get_all_line_items()
         assert len(line_items_db) == 1
         assert line_items_db[0]["id"] == line_item_id
         assert line_items_db[0]["description"] == "DAO test transaction"
@@ -328,7 +328,7 @@ def test_delete_manual_transaction_removes_transaction_and_line_item(flask_app):
 
         # Verify it exists
         assert len(get_transactions("manual", None)) == 1
-        assert len(get_all_line_items(None)) == 1
+        assert len(get_all_line_items()) == 1
 
         # Delete it
         result = delete_manual_transaction(transaction_id)
@@ -336,7 +336,7 @@ def test_delete_manual_transaction_removes_transaction_and_line_item(flask_app):
 
         # Verify it's gone
         assert len(get_transactions("manual", None)) == 0
-        assert len(get_all_line_items(None)) == 0
+        assert len(get_all_line_items()) == 0
 
 
 def test_delete_manual_transaction_returns_false_for_nonexistent(flask_app):


### PR DESCRIPTION
## Summary
Refactored the `get_all_line_items()` function to replace a generic `filters` dictionary parameter with explicit, named parameters. This improves code clarity, type safety, and maintainability by making the function's interface more explicit about what filtering options are supported.

## Key Changes
- **Function signature**: Changed `get_all_line_items(filters: Optional[Dict[str, Any]], ...)` to `get_all_line_items(ids: Optional[List[str]] = None, payment_method: Optional[str] = None, only_unreviewed: bool = False, ...)`
- **Filter logic simplification**: Replaced complex dictionary-based filter handling with straightforward conditional checks:
  - `filters["id"]["$in"]` pattern → `ids` parameter
  - `filters["payment_method"]` → `payment_method` parameter  
  - `filters["event_id"]["$exists"]` pattern → `only_unreviewed` boolean parameter
- **Call site updates**: Updated all 20+ call sites across test files and resource modules to use the new parameter names instead of constructing filter dictionaries
- **Resource layer updates**: Simplified `line_item.py` and `event.py` to pass parameters directly instead of building intermediate filter objects

## Implementation Details
- The refactoring maintains backward compatibility in behavior while improving the API surface
- Boolean parameter `only_unreviewed` replaces the MongoDB-style `{"$exists": False}` pattern for better readability
- All filtering logic remains unchanged; only the parameter passing mechanism was refactored
- This change aligns with the project philosophy of preferring explicit, maintainable code over generic dictionary-based patterns

https://claude.ai/code/session_01B3UhZB1QdnnURwsQzBFNJJ