### PR TITLE
Make tags user-scoped instead of globally unique

### DIFF
--- a/.github/workflows/migration-reminder.yml
+++ b/.github/workflows/migration-reminder.yml
@@ -35,5 +35,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `### 🗄️ Database migration required\n\nThis PR adds ${files.length === 1 ? 'a new migration' : 'new migrations'}:\n${list}\n\nAfter merging, run it in production via the [Run Migrations](../../actions/workflows/run-migrations.yml) workflow.`,
+              body: `### 🗄️ Database migration required\n\nThis PR adds ${files.length === 1 ? 'a new migration' : 'new migrations'}:\n${list}\n\nAfter merging, run it in production via the [Run Migrations](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/workflows/run-migrations.yml) workflow.`,
             });

--- a/.github/workflows/migration-reminder.yml
+++ b/.github/workflows/migration-reminder.yml
@@ -1,0 +1,39 @@
+name: Migration reminder
+
+on:
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "server/alembic/versions/**.py"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find new migration files
+        id: migrations
+        run: |
+          files=$(git diff --name-only --diff-filter=A origin/main...HEAD -- 'server/alembic/versions/*.py')
+          echo "files=$files" >> $GITHUB_OUTPUT
+
+      - name: Post reminder comment
+        if: steps.migrations.outputs.files != ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const files = `${{ steps.migrations.outputs.files }}`.trim().split('\n');
+            const list = files.map(f => `- \`${f}\``).join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: `### 🗄️ Database migration required\n\nThis PR adds ${files.length === 1 ? 'a new migration' : 'new migrations'}:\n${list}\n\nAfter merging, run it in production via the [Run Migrations](../../actions/workflows/run-migrations.yml) workflow.`,
+            });

--- a/server/alembic/versions/c3d4e5f6a7b8_add_user_id_to_tags.py
+++ b/server/alembic/versions/c3d4e5f6a7b8_add_user_id_to_tags.py
@@ -1,0 +1,65 @@
+"""add user_id to tags
+
+Revision ID: c3d4e5f6a7b8
+Revises: b1c2d3e4f5a6
+Create Date: 2026-06-14 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c3d4e5f6a7b8"
+down_revision: Union[str, Sequence[str], None] = "b1c2d3e4f5a6"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # Step 1: Drop the old global unique constraint on name
+    op.drop_constraint("tags_name_key", "tags", type_="unique")
+
+    # Step 2: Add user_id column (nullable initially to handle existing data)
+    op.add_column("tags", sa.Column("user_id", sa.String(255), nullable=True))
+
+    # Step 3: Backfill user_id from the first (only) user so existing rows are valid
+    connection = op.get_bind()
+    result = connection.execute(sa.text("SELECT id FROM users LIMIT 1"))
+    first_user = result.fetchone()
+
+    if first_user:
+        user_id = first_user[0]
+        connection.execute(sa.text("UPDATE tags SET user_id = :user_id WHERE user_id IS NULL"), {"user_id": user_id})
+
+    # Step 4: Make user_id NOT NULL and add foreign key
+    op.alter_column("tags", "user_id", nullable=False)
+    op.create_foreign_key("fk_tags_user_id", "tags", "users", ["user_id"], ["id"], ondelete="CASCADE")
+
+    # Step 5: Create index on user_id
+    op.create_index("ix_tags_user_id", "tags", ["user_id"])
+
+    # Step 6: Create unique constraint on (user_id, name)
+    op.create_unique_constraint("uq_user_tag_name", "tags", ["user_id", "name"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Drop the new unique constraint
+    op.drop_constraint("uq_user_tag_name", "tags", type_="unique")
+
+    # Drop the index
+    op.drop_index("ix_tags_user_id", table_name="tags")
+
+    # Drop the foreign key
+    op.drop_constraint("fk_tags_user_id", "tags", type_="foreignkey")
+
+    # Drop user_id column
+    op.drop_column("tags", "user_id")
+
+    # Re-add global unique constraint on name
+    op.create_unique_constraint("tags_name_key", "tags", ["name"])

--- a/server/models/sql_models.py
+++ b/server/models/sql_models.py
@@ -110,13 +110,19 @@ class Tag(Base):
     __tablename__ = "tags"
 
     id = Column(String(255), primary_key=True)  # tag_xxx
-    name = Column(String(100), nullable=False, unique=True)
+    user_id = Column(String(255), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    name = Column(String(100), nullable=False)
     created_at = Column(TIMESTAMP(timezone=True), default=lambda: datetime.now(UTC))
     updated_at = Column(
         TIMESTAMP(timezone=True),
         default=lambda: datetime.now(UTC),
         onupdate=lambda: datetime.now(UTC),
     )
+
+    # Relationships
+    user = relationship("User")
+
+    __table_args__ = (UniqueConstraint("user_id", "name", name="uq_user_tag_name"),)
 
 
 class Transaction(Base):

--- a/server/resources/event.py
+++ b/server/resources/event.py
@@ -95,7 +95,7 @@ def post_event_api() -> tuple[Response, int]:
 
     from utils.pg_event_operations import upsert_event
 
-    pg_event_id = upsert_event(new_event)
+    pg_event_id = upsert_event(new_event, get_current_user()["id"])
     new_event["id"] = pg_event_id
 
     logger.info(f"Created event: {new_event['id']} with {len(line_items)} line items (amount: ${new_event['amount']:.2f})")
@@ -142,7 +142,7 @@ def update_event_api(event_id: str) -> tuple[Response, int]:
 
     from utils.pg_event_operations import upsert_event
 
-    upsert_event(event_dict)
+    upsert_event(event_dict, get_current_user()["id"])
 
     # Calculate updated amount for response
     if event_dict.get("is_duplicate_transaction"):

--- a/server/resources/tags.py
+++ b/server/resources/tags.py
@@ -1,7 +1,7 @@
 import logging
 
 from flask import Blueprint, Response, jsonify
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import get_current_user, jwt_required
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +14,8 @@ def get_all_tags_api() -> tuple[Response, int]:
     from models.database import SessionLocal
     from models.sql_models import Tag
 
+    user = get_current_user()
     with SessionLocal.begin() as db:
-        tags = db.query(Tag).order_by(Tag.name).all()
+        tags = db.query(Tag).filter(Tag.user_id == user["id"]).order_by(Tag.name).all()
         tags_list = [{"id": tag.id, "name": tag.name} for tag in tags]
         return jsonify({"data": tags_list}), 200

--- a/server/tests/test_event.py
+++ b/server/tests/test_event.py
@@ -734,7 +734,7 @@ class TestEventAPI:
             from utils.pg_event_operations import upsert_event_to_postgresql
 
             with SessionLocal.begin() as db:
-                upsert_event_to_postgresql(test_event, db)
+                upsert_event_to_postgresql(test_event, db, "user_id")
 
             # Get the actual PostgreSQL event ID that was created
             all_events = get_all_events(None)

--- a/server/tests/test_helpers.py
+++ b/server/tests/test_helpers.py
@@ -74,6 +74,7 @@ def setup_test_event(
     pg_session,
     event_data: Dict[str, Any],
     line_items: Optional[List[LineItem]] = None,
+    user_id: str = "user_id",
 ) -> Event:
     """
     Create an event in PostgreSQL.
@@ -120,10 +121,11 @@ def setup_test_event(
         from models.sql_models import EventTag, Tag
 
         for tag_name in event_data["tags"]:
-            tag = pg_session.query(Tag).filter(Tag.name == tag_name).first()
+            tag = pg_session.query(Tag).filter(Tag.user_id == user_id, Tag.name == tag_name).first()
             if not tag:
                 tag = Tag(
                     id=generate_id("tag"),
+                    user_id=user_id,
                     name=tag_name,
                     created_at=datetime.now(UTC),
                     updated_at=datetime.now(UTC),

--- a/server/tests/test_tags.py
+++ b/server/tests/test_tags.py
@@ -6,10 +6,11 @@ def sample_tags(pg_session):
     """Create sample tags for testing"""
     from models.sql_models import Tag
 
+    user_id = "user_id"
     tags_data = [
-        {"id": "tag_1", "name": "vacation"},
-        {"id": "tag_2", "name": "groceries"},
-        {"id": "tag_3", "name": "birthday"},
+        {"id": "tag_1", "user_id": user_id, "name": "vacation"},
+        {"id": "tag_2", "user_id": user_id, "name": "groceries"},
+        {"id": "tag_3", "user_id": user_id, "name": "birthday"},
     ]
 
     tags = [Tag(**tag_data) for tag_data in tags_data]
@@ -54,3 +55,30 @@ class TestTagsAPI:
         response = test_client.get("/api/tags")
 
         assert response.status_code == 401
+
+    def test_tags_from_other_users_are_not_returned(self, test_client, flask_app, pg_session, sample_tags):
+        """Tags belonging to a different user are not visible"""
+        from flask_jwt_extended import create_access_token
+
+        from models.sql_models import Tag, User
+
+        other_user = User(
+            id="user_other",
+            first_name="Other",
+            last_name="User",
+            email="other@example.com",
+            password_hash="hashed",
+        )
+        pg_session.add(other_user)
+        pg_session.flush()
+        pg_session.add(Tag(id="tag_other", user_id="user_other", name="secret"))
+        pg_session.commit()
+
+        with flask_app.app_context():
+            other_token = create_access_token(identity="user_other")
+
+        response = test_client.get("/api/tags", headers={"Authorization": f"Bearer {other_token}"})
+        assert response.status_code == 200
+        data = response.get_json()
+        assert len(data["data"]) == 1
+        assert data["data"][0]["name"] == "secret"

--- a/server/utils/pg_event_operations.py
+++ b/server/utils/pg_event_operations.py
@@ -11,7 +11,7 @@ from utils.id_generator import generate_id
 logger = logging.getLogger(__name__)
 
 
-def upsert_event_to_postgresql(event_dict: Dict[str, Any], db_session) -> str:
+def upsert_event_to_postgresql(event_dict: Dict[str, Any], db_session, user_id: str) -> str:
     """
     Write event to PostgreSQL with all relationships.
 
@@ -93,13 +93,14 @@ def upsert_event_to_postgresql(event_dict: Dict[str, Any], db_session) -> str:
     # Create EventTag junctions (batch-fetch existing tags to avoid N+1)
     tag_names = event_dict.get("tags", [])
     if tag_names:
-        existing_tags = db_session.query(Tag).filter(Tag.name.in_(tag_names)).all()
+        existing_tags = db_session.query(Tag).filter(Tag.user_id == user_id, Tag.name.in_(tag_names)).all()
         tag_map = {t.name: t for t in existing_tags}
         for tag_name in tag_names:
             tag = tag_map.get(tag_name)
             if not tag:
                 tag = Tag(
                     id=generate_id("tag"),
+                    user_id=user_id,
                     name=tag_name,
                     created_at=datetime.now(UTC),
                     updated_at=datetime.now(UTC),
@@ -119,12 +120,12 @@ def upsert_event_to_postgresql(event_dict: Dict[str, Any], db_session) -> str:
     return pg_event_id
 
 
-def upsert_event(event_dict: Dict[str, Any]) -> str:
+def upsert_event(event_dict: Dict[str, Any], user_id: str) -> str:
     """
     Upsert an event while managing the session lifecycle.
     """
     with SessionLocal.begin() as db_session:
-        pg_event_id = upsert_event_to_postgresql(event_dict, db_session)
+        pg_event_id = upsert_event_to_postgresql(event_dict, db_session, user_id)
         return pg_event_id
 
 


### PR DESCRIPTION
## Summary
This PR converts tags from a global resource to a user-scoped resource. Each user now has their own set of tags, and tag names are only required to be unique within a user's scope rather than globally.

## Key Changes
- **Database schema**: Added `user_id` foreign key to `tags` table and changed uniqueness constraint from global `name` to composite `(user_id, name)`
- **Migration**: Created Alembic migration that safely backfills existing tags to the first user, then enforces the new schema
- **API filtering**: Updated `/api/tags` endpoint to return only tags belonging to the authenticated user
- **Event operations**: Modified tag creation/lookup in event upsert to filter by user ID, ensuring users only see and interact with their own tags
- **Test coverage**: Added test verifying tags from other users are not visible, and updated test fixtures to include `user_id`
- **CI/CD**: Added GitHub Actions workflow to remind reviewers when migrations are added

## Implementation Details
- Tags are backfilled to the first user during migration to maintain data integrity for existing deployments
- Foreign key uses `CASCADE` delete to clean up tags when a user is deleted
- Index added on `user_id` for efficient filtering
- All tag queries now filter by `user_id` from the authenticated user context

https://claude.ai/code/session_01MNZmYwDSXUsNaF3Bot3sDA