### PR TITLE
Add SessionStart hook to auto-install dependencies in fresh containers

### DIFF
--- a/.claude/hooks/README.md
+++ b/.claude/hooks/README.md
@@ -2,6 +2,32 @@
 
 This directory contains hooks for Claude Code that automate quality checks during development.
 
+## Session Setup Hook
+
+The `session-setup.sh` hook runs automatically on `SessionStart` to install
+project dependencies, so a fresh container is ready to run tests before the
+first commit.
+
+### Why it exists
+
+Fresh Claude Code (web/remote) containers clone the repo but never install
+dependencies. Because `client/node_modules/` is gitignored, the client's local
+`jest` binary is missing, and the pre-commit test hook fails with
+`jest: not found` — blocking commits even for server-only changes.
+
+### What it does
+
+1. **Client deps**: runs `npm ci --legacy-peer-deps` in `client/` (matches CI), skipping if already installed
+2. **Server deps**: runs `uv sync` in `server/` (matches CI)
+3. **Never blocks the session**: if an install fails (e.g. offline / restricted network policy) it logs a warning and exits 0; the pre-commit hook then surfaces a clear, actionable message
+
+### Configuration
+
+Registered as a `SessionStart` hook in `.claude/settings.json` with a 600s
+timeout (a cold `npm ci` can take a few minutes).
+
+---
+
 ## Pre-Commit Lint Hook
 
 The `pre-commit-lint.py` hook runs `make lint-fix` before commits to auto-fix linting issues.

--- a/.claude/hooks/pre-commit-test.py
+++ b/.claude/hooks/pre-commit-test.py
@@ -71,6 +71,13 @@ def run_client_tests(project_dir: str) -> tuple[bool, str]:
     if not os.path.exists(client_dir):
         return True, "No client directory found, skipping client tests"
 
+    if not os.path.isdir(os.path.join(client_dir, 'node_modules')):
+        return False, (
+            "Client dependencies not installed (no client/node_modules), so jest is "
+            "unavailable. Run `npm ci --legacy-peer-deps` in client/ or re-run "
+            ".claude/hooks/session-setup.sh, then commit again."
+        )
+
     try:
         result = subprocess.run(
             ['npm', 'test'],

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+#
+# SessionStart hook: provision client and server dependencies.
+#
+# Fresh Claude Code (web/remote) containers clone the repo but never install
+# dependencies. Because client/node_modules is gitignored, the local `jest`
+# binary is missing and the pre-commit test hook fails with "jest: not found".
+# This script installs deps once, up front, mirroring the commands CI uses.
+#
+# Notes:
+# - No `set -e`: a failed install (e.g. offline container) must NOT abort the
+#   session. We always exit 0 and let the pre-commit hook surface a clear
+#   message if deps are still missing.
+# - Output is kept brief because SessionStart stdout is added to the context.
+
+set -u
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+
+log() { echo "[session-setup] $*" >&2; }
+
+# Install client dependencies (matches .github/workflows/nodejs-client.yml).
+if [ -d "$PROJECT_DIR/client" ]; then
+  if command -v npm >/dev/null 2>&1; then
+    if [ -d "$PROJECT_DIR/client/node_modules/.bin" ]; then
+      log "client deps already present, skipping npm ci"
+    else
+      log "installing client deps (npm ci --legacy-peer-deps)..."
+      if (cd "$PROJECT_DIR/client" && npm ci --legacy-peer-deps >&2); then
+        log "client deps installed"
+      else
+        log "WARNING: npm ci failed (offline or network policy?); client tests may not run"
+      fi
+    fi
+  else
+    log "WARNING: npm not found; skipping client deps"
+  fi
+fi
+
+# Install server dependencies (matches .github/workflows/python-app.yml).
+if [ -d "$PROJECT_DIR/server" ]; then
+  if command -v uv >/dev/null 2>&1; then
+    log "syncing server deps (uv sync)..."
+    if (cd "$PROJECT_DIR/server" && uv sync >&2); then
+      log "server deps synced"
+    else
+      log "WARNING: uv sync failed (offline or network policy?); server tests may not run"
+    fi
+  else
+    log "WARNING: uv not found; skipping server deps"
+  fi
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,16 @@
 {
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/session-setup.sh",
+            "timeout": 600
+          }
+        ]
+      }
+    ],
     "PreToolUse": [
       {
         "matcher": "Bash",


### PR DESCRIPTION
## Summary

Adds a `SessionStart` hook that automatically installs project dependencies when Claude Code containers start, ensuring fresh environments are ready to run tests before the first commit.

## Problem

Fresh Claude Code (web/remote) containers clone the repo but don't install dependencies. Since `client/node_modules/` is gitignored, the local `jest` binary is missing, causing the pre-commit test hook to fail with `jest: not found` — even for server-only changes.

## Solution

- **New `session-setup.sh` hook**: Runs on `SessionStart` to install client and server dependencies, mirroring CI commands:
  - Client: `npm ci --legacy-peer-deps` in `client/`
  - Server: `uv sync` in `server/`
  - Gracefully handles missing tools and network failures (logs warnings, exits 0)
  - Skips reinstall if dependencies already present

- **Updated `pre-commit-test.py`**: Added explicit check for missing `client/node_modules/` with a clear, actionable error message directing users to run the session setup hook

- **Updated `.claude/settings.json`**: Registered the hook as a `SessionStart` command with 600s timeout (cold `npm ci` can take several minutes)

- **Updated `.claude/hooks/README.md`**: Documented the new hook, its purpose, and configuration

## Implementation Details

- Hook uses `set -u` for safety but deliberately avoids `set -e` — failed installs must not abort the session, allowing the pre-commit hook to surface a clear message if deps are still missing
- Output is kept brief since `SessionStart` stdout is added to Claude's context
- Checks for tool availability (`npm`, `uv`) before attempting installs
- Uses `CLAUDE_PROJECT_DIR` environment variable with fallback to script location for portability

https://claude.ai/code/session_01QVtEcTJcU7S3cBdFCR9HVz