### PR TITLE
Optimize queries and event mutations

### DIFF
--- a/client/src/components/CreateEventModal.tsx
+++ b/client/src/components/CreateEventModal.tsx
@@ -6,7 +6,7 @@ import { ResponsiveDialog, useIsMobile } from "@/components/ui/responsive-dialog
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import React, { useEffect, useState } from 'react';
 import { Body } from "../components/ui/typography";
-import { LineItemInterface, useLineItems } from "../contexts/LineItemsContext";
+import { LineItemInterface, useLineItems, useLineItemsDispatch } from "../contexts/LineItemsContext";
 import { useCategories, useCreateEvent, useEvaluateEventHints, useTags } from '../hooks/useApi';
 import { useField } from '../hooks/useField';
 import { calculateEventTotal } from '../utils/eventHelpers';
@@ -39,6 +39,7 @@ function CreateEventModalContent({
   isLoadingHints,
 }: CreateEventModalContentProps) {
   const createEventMutation = useCreateEvent();
+  const lineItemsDispatch = useLineItemsDispatch();
 
   // Form fields initialize with props - when parent changes the key, this component
   // remounts with fresh state using the new initial values
@@ -82,6 +83,7 @@ function CreateEventModalContent({
     };
     createEventMutation.mutate(newEvent, {
       onSuccess: (response: { name?: string }) => {
+        lineItemsDispatch({ type: "remove_line_items", lineItemIds: selectedLineItemIds });
         onClose();
         showSuccessToast(response.name || newEvent.name, "Created Event");
       },

--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -1,4 +1,4 @@
-import { useMutation, UseMutationResult, useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
+import { keepPreviousData, useMutation, UseMutationResult, useQuery, useQueryClient, UseQueryResult } from '@tanstack/react-query';
 import { EventInterface } from '../components/Event';
 import { LineItemInterface } from '../contexts/LineItemsContext';
 import type { components } from '../types/api.generated';
@@ -6,8 +6,11 @@ import axiosInstance from '../utils/axiosInstance';
 
 // Query Keys
 export const queryKeys = {
-  events: (startTime?: number, endTime?: number) => ['events', startTime, endTime] as const,
-  lineItems: (params?: { onlyLineItemsToReview?: boolean; paymentMethod?: string }) =>
+  events: (startTime?: number, endTime?: number, limit?: number, offset?: number) =>
+    limit !== undefined || offset !== undefined
+      ? ['events', startTime, endTime, limit, offset] as const
+      : ['events', startTime, endTime] as const,
+  lineItems: (params?: { onlyLineItemsToReview?: boolean; paymentMethod?: string; limit?: number; offset?: number }) =>
     ['lineItems', params] as const,
   eventLineItems: (eventId: string) => ['eventLineItems', eventId] as const,
   monthlyBreakdown: () => ['monthlyBreakdown'] as const,
@@ -22,10 +25,15 @@ export const queryKeys = {
   categories: () => ['categories'] as const,
 };
 
+const listQueryOptions = {
+  placeholderData: keepPreviousData,
+  staleTime: 5 * 60 * 1000,
+};
+
 // Query Hooks
 export function useEvents(startTime?: number, endTime?: number, limit?: number, offset?: number): UseQueryResult<EventInterface[]> {
   return useQuery({
-    queryKey: queryKeys.events(startTime, endTime),
+    queryKey: queryKeys.events(startTime, endTime, limit, offset),
     queryFn: async () => {
       const response = await axiosInstance.get('api/events', {
         params: {
@@ -38,12 +46,18 @@ export function useEvents(startTime?: number, endTime?: number, limit?: number, 
       return response.data.data as EventInterface[];
     },
     enabled: !!startTime && !!endTime,
+    ...listQueryOptions,
   });
 }
 
 export function useLineItems(params?: { onlyLineItemsToReview?: boolean; paymentMethod?: string; enabled?: boolean; limit?: number; offset?: number }): UseQueryResult<LineItemInterface[]> {
   return useQuery({
-    queryKey: queryKeys.lineItems(params ? { onlyLineItemsToReview: params.onlyLineItemsToReview, paymentMethod: params.paymentMethod } : undefined),
+    queryKey: queryKeys.lineItems(params ? {
+      onlyLineItemsToReview: params.onlyLineItemsToReview,
+      paymentMethod: params.paymentMethod,
+      limit: params.limit,
+      offset: params.offset,
+    } : undefined),
     queryFn: async () => {
       const queryParams: Record<string, string | boolean | number> = {};
 
@@ -64,6 +78,7 @@ export function useLineItems(params?: { onlyLineItemsToReview?: boolean; payment
       return response.data.data as LineItemInterface[];
     },
     enabled: params?.enabled ?? true,
+    ...listQueryOptions,
   });
 }
 
@@ -75,6 +90,7 @@ export function useEventLineItems(eventId: string): UseQueryResult<LineItemInter
       return response.data.data as LineItemInterface[];
     },
     enabled: !!eventId,
+    ...listQueryOptions,
   });
 }
 
@@ -89,6 +105,7 @@ export function useMonthlyBreakdown(): UseQueryResult<MonthlyBreakdownData> {
       const response = await axiosInstance.get('api/monthly_breakdown');
       return response.data;
     },
+    staleTime: 5 * 60 * 1000,
   });
 }
 
@@ -141,6 +158,7 @@ export function usePaymentMethods(): UseQueryResult<PaymentMethod[]> {
       const response = await axiosInstance.get('api/payment_methods');
       return response.data.data as PaymentMethod[];
     },
+    staleTime: 10 * 60 * 1000,
   });
 }
 
@@ -181,6 +199,7 @@ export function useTags(): UseQueryResult<Tag[]> {
       const response = await axiosInstance.get('api/tags');
       return response.data.data as Tag[];
     },
+    staleTime: 10 * 60 * 1000,
   });
 }
 
@@ -201,6 +220,22 @@ export function useCreateEvent(): UseMutationResult<unknown, Error, CreateEventD
     mutationFn: async (eventData: CreateEventData) => {
       const response = await axiosInstance.post('api/events', eventData);
       return response.data;
+    },
+    onMutate: async (eventData) => {
+      await queryClient.cancelQueries({ queryKey: ['lineItems'] });
+      const previousLineItems = queryClient.getQueriesData<LineItemInterface[]>({ queryKey: ['lineItems'] });
+      const reviewedIds = new Set(eventData.line_items);
+
+      queryClient.setQueriesData<LineItemInterface[]>({ queryKey: ['lineItems'] }, (old) =>
+        old?.filter((lineItem) => !reviewedIds.has(lineItem.id))
+      );
+
+      return { previousLineItems };
+    },
+    onError: (_error, _eventData, context) => {
+      context?.previousLineItems.forEach(([queryKey, data]) => {
+        queryClient.setQueryData(queryKey, data);
+      });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['lineItems'] });
@@ -435,6 +470,7 @@ export function useEventHints(): UseQueryResult<EventHint[]> {
       const response = await axiosInstance.get('api/event-hints');
       return response.data.data as EventHint[];
     },
+    staleTime: 10 * 60 * 1000,
   });
 }
 
@@ -445,6 +481,7 @@ export function useCategories(): UseQueryResult<CategoryOption[]> {
       const response = await axiosInstance.get('api/categories');
       return response.data.data as CategoryOption[];
     },
+    staleTime: 10 * 60 * 1000,
   });
 }
 

--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -25,9 +25,13 @@ export const queryKeys = {
   categories: () => ['categories'] as const,
 };
 
+const MINUTE_MS = 60 * 1000;
+const LIST_STALE_TIME_MS = 5 * MINUTE_MS;
+const LOOKUP_STALE_TIME_MS = 10 * MINUTE_MS;
+
 const listQueryOptions = {
   placeholderData: keepPreviousData,
-  staleTime: 5 * 60 * 1000,
+  staleTime: LIST_STALE_TIME_MS,
 };
 
 // Query Hooks
@@ -105,7 +109,7 @@ export function useMonthlyBreakdown(): UseQueryResult<MonthlyBreakdownData> {
       const response = await axiosInstance.get('api/monthly_breakdown');
       return response.data;
     },
-    staleTime: 5 * 60 * 1000,
+    staleTime: LIST_STALE_TIME_MS,
   });
 }
 
@@ -158,7 +162,7 @@ export function usePaymentMethods(): UseQueryResult<PaymentMethod[]> {
       const response = await axiosInstance.get('api/payment_methods');
       return response.data.data as PaymentMethod[];
     },
-    staleTime: 10 * 60 * 1000,
+    staleTime: LOOKUP_STALE_TIME_MS,
   });
 }
 
@@ -199,7 +203,7 @@ export function useTags(): UseQueryResult<Tag[]> {
       const response = await axiosInstance.get('api/tags');
       return response.data.data as Tag[];
     },
-    staleTime: 10 * 60 * 1000,
+    staleTime: LOOKUP_STALE_TIME_MS,
   });
 }
 
@@ -238,10 +242,12 @@ export function useCreateEvent(): UseMutationResult<unknown, Error, CreateEventD
       });
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['lineItems'] });
       queryClient.invalidateQueries({ queryKey: ['events'], refetchType: 'none' });
       queryClient.invalidateQueries({ queryKey: ['monthlyBreakdown'], refetchType: 'none' });
       queryClient.invalidateQueries({ queryKey: ['tags'], refetchType: 'none' });
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['lineItems'] });
     },
   });
 }
@@ -470,7 +476,7 @@ export function useEventHints(): UseQueryResult<EventHint[]> {
       const response = await axiosInstance.get('api/event-hints');
       return response.data.data as EventHint[];
     },
-    staleTime: 10 * 60 * 1000,
+    staleTime: LOOKUP_STALE_TIME_MS,
   });
 }
 
@@ -481,7 +487,7 @@ export function useCategories(): UseQueryResult<CategoryOption[]> {
       const response = await axiosInstance.get('api/categories');
       return response.data.data as CategoryOption[];
     },
-    staleTime: 10 * 60 * 1000,
+    staleTime: LOOKUP_STALE_TIME_MS,
   });
 }
 

--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -545,6 +545,7 @@ export function useEvaluateEventHints(lineItemIds: string[], enabled: boolean = 
       return response.data.data.suggestion as EventHintSuggestion | null;
     },
     enabled: enabled && lineItemIds.length > 0,
+    staleTime: LIST_STALE_TIME_MS,
   });
 }
 

--- a/client/src/pages/EventsPage.tsx
+++ b/client/src/pages/EventsPage.tsx
@@ -39,7 +39,7 @@ export default function EventsPage() {
         endTime = start.endOf("year").toUnixInteger()
     }
 
-    const { data: events = [], isLoading, error } = useEvents(startTime, endTime)
+    const { data: events = [], isLoading, isFetching, error } = useEvents(startTime, endTime)
 
     const matchCategory = (event: EventInterface) => category === "All" || category === event.category
 
@@ -126,6 +126,11 @@ export default function EventsPage() {
                         <CategoryFilter category={category} setCategory={setCategory} />
                         <TagsFilter tagFilter={tagFilter} setTagFilter={setTagFilter} />
                     </div>
+                    {isFetching && !isLoading && (
+                        <div className="flex justify-end">
+                            <Spinner size="sm" className="text-muted-foreground" />
+                        </div>
+                    )}
                 </div>
 
                 {/* Summary cards */}

--- a/client/src/pages/LineItemsPage.tsx
+++ b/client/src/pages/LineItemsPage.tsx
@@ -10,7 +10,7 @@ import { useLineItems } from "../hooks/useApi";
 export default function LineItemsPage() {
     const [paymentMethod, setPaymentMethod] = useState("All")
 
-    const { data: lineItems = [], isLoading, error } = useLineItems({ paymentMethod })
+    const { data: lineItems = [], isLoading, isFetching, error } = useLineItems({ paymentMethod })
 
     return (
         <PageContainer>
@@ -24,6 +24,11 @@ export default function LineItemsPage() {
             <div className="space-y-6">
                 <div className="flex flex-col sm:flex-row gap-4">
                     <PaymentMethodFilter paymentMethod={paymentMethod} setPaymentMethod={setPaymentMethod} />
+                    {isFetching && !isLoading && (
+                        <div className="flex items-center">
+                            <Spinner size="sm" className="text-muted-foreground" />
+                        </div>
+                    )}
                 </div>
 
                 {/* Mobile card layout */}

--- a/server/alembic/versions/d4e5f6a7b8c9_add_indexes_for_hot_list_queries.py
+++ b/server/alembic/versions/d4e5f6a7b8c9_add_indexes_for_hot_list_queries.py
@@ -1,0 +1,37 @@
+"""add indexes for hot list queries
+
+Revision ID: d4e5f6a7b8c9
+Revises: c3d4e5f6a7b8
+Create Date: 2026-06-16 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "d4e5f6a7b8c9"
+down_revision: Union[str, Sequence[str], None] = "c3d4e5f6a7b8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_index("ix_events_date", "events", ["date"])
+    op.create_index("ix_line_items_date", "line_items", ["date"])
+    op.create_index("ix_line_items_payment_method_date", "line_items", ["payment_method_id", "date"])
+    op.create_index("ix_event_tags_event_id", "event_tags", ["event_id"])
+    op.create_index("ix_event_tags_tag_id", "event_tags", ["tag_id"])
+    op.create_index("ix_transactions_source_transaction_date", "transactions", ["source", "transaction_date"])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index("ix_transactions_source_transaction_date", table_name="transactions")
+    op.drop_index("ix_event_tags_tag_id", table_name="event_tags")
+    op.drop_index("ix_event_tags_event_id", table_name="event_tags")
+    op.drop_index("ix_line_items_payment_method_date", table_name="line_items")
+    op.drop_index("ix_line_items_date", table_name="line_items")
+    op.drop_index("ix_events_date", table_name="events")

--- a/server/models/sql_models.py
+++ b/server/models/sql_models.py
@@ -10,6 +10,7 @@ from sqlalchemy import (
     Column,
     Enum,
     ForeignKey,
+    Index,
     Integer,
     String,
     Text,
@@ -127,7 +128,10 @@ class Tag(Base):
 
 class Transaction(Base):
     __tablename__ = "transactions"
-    __table_args__ = (UniqueConstraint("source", "source_id", name="uq_transaction_source"),)
+    __table_args__ = (
+        UniqueConstraint("source", "source_id", name="uq_transaction_source"),
+        Index("ix_transactions_source_transaction_date", "source", "transaction_date"),
+    )
 
     id = Column(String(255), primary_key=True)  # txn_xxx
     source = Column(
@@ -143,11 +147,14 @@ class Transaction(Base):
 
 class LineItem(Base):
     __tablename__ = "line_items"
-    __table_args__ = (UniqueConstraint("transaction_id", name="uq_line_item_transaction"),)
+    __table_args__ = (
+        UniqueConstraint("transaction_id", name="uq_line_item_transaction"),
+        Index("ix_line_items_payment_method_date", "payment_method_id", "date"),
+    )
 
     id = Column(String(255), primary_key=True)  # li_xxx
     transaction_id = Column(String(255), ForeignKey("transactions.id", ondelete="CASCADE"), nullable=False, index=True)
-    date = Column(TIMESTAMP(timezone=True), nullable=False)
+    date = Column(TIMESTAMP(timezone=True), nullable=False, index=True)
     amount = Column(DECIMAL(12, 2), nullable=False)
     description = Column(Text, nullable=False)
     payment_method_id = Column(
@@ -175,7 +182,7 @@ class Event(Base):
     __tablename__ = "events"
 
     id = Column(String(255), primary_key=True)  # evt_xxx
-    date = Column(TIMESTAMP(timezone=True), nullable=False)
+    date = Column(TIMESTAMP(timezone=True), nullable=False, index=True)
     description = Column(Text, nullable=False)
     category_id = Column(String(255), ForeignKey("categories.id", ondelete="RESTRICT"), nullable=False, index=True)
     is_duplicate = Column(Boolean, default=False)
@@ -218,8 +225,8 @@ class EventTag(Base):
     __table_args__ = (UniqueConstraint("event_id", "tag_id", name="uq_event_tag"),)
 
     id = Column(String(255), primary_key=True)  # etag_xxx
-    event_id = Column(String(255), ForeignKey("events.id", ondelete="CASCADE"), nullable=False)
-    tag_id = Column(String(255), ForeignKey("tags.id", ondelete="CASCADE"), nullable=False)
+    event_id = Column(String(255), ForeignKey("events.id", ondelete="CASCADE"), nullable=False, index=True)
+    tag_id = Column(String(255), ForeignKey("tags.id", ondelete="CASCADE"), nullable=False, index=True)
     created_at = Column(TIMESTAMP(timezone=True), default=lambda: datetime.now(UTC))
 
 

--- a/server/queries.py
+++ b/server/queries.py
@@ -1,8 +1,9 @@
 from typing import Any, Dict, List, Optional
 
+from sqlalchemy import func
 from sqlalchemy.orm import joinedload, subqueryload
 
-from serializers import serialize_event, serialize_line_item, serialize_user
+from serializers import serialize_datetime, serialize_event, serialize_line_item, serialize_user
 
 
 def get_user_by_email(email: str) -> Optional[Dict[str, Any]]:
@@ -28,32 +29,71 @@ def get_all_line_items(
     only_unreviewed: bool = False,
     limit: Optional[int] = None,
     offset: int = 0,
+    event_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Get line items from PostgreSQL"""
     from models.database import SessionLocal
-    from models.sql_models import Event, LineItem, PaymentMethod
+    from models.sql_models import EventLineItem, LineItem, PaymentMethod, Transaction
 
     with SessionLocal.begin() as db:
-        query = db.query(LineItem).options(
-            joinedload(LineItem.payment_method),
-            joinedload(LineItem.events),
-            joinedload(LineItem.transaction),
+        event_id_col = func.min(EventLineItem.event_id).label("event_id")
+        query = (
+            db.query(
+                LineItem.id,
+                LineItem.date,
+                PaymentMethod.name.label("payment_method"),
+                LineItem.description,
+                LineItem.amount,
+                LineItem.responsible_party,
+                LineItem.notes,
+                Transaction.source.label("transaction_source"),
+                event_id_col,
+            )
+            .join(PaymentMethod, LineItem.payment_method_id == PaymentMethod.id)
+            .join(Transaction, LineItem.transaction_id == Transaction.id)
+            .outerjoin(EventLineItem, EventLineItem.line_item_id == LineItem.id)
         )
 
         if ids is not None:
             query = query.filter(LineItem.id.in_(ids))
         if payment_method and payment_method != "All":
-            query = query.join(LineItem.payment_method).filter(PaymentMethod.name == payment_method)
+            query = query.filter(PaymentMethod.name == payment_method)
+        if event_id:
+            query = query.filter(EventLineItem.event_id == event_id)
         if only_unreviewed:
-            query = query.outerjoin(LineItem.events).filter(Event.id.is_(None))
+            query = query.filter(EventLineItem.event_id.is_(None))
 
-        query = query.order_by(LineItem.date.desc())
+        query = query.group_by(
+            LineItem.id,
+            LineItem.date,
+            PaymentMethod.name,
+            LineItem.description,
+            LineItem.amount,
+            LineItem.responsible_party,
+            LineItem.notes,
+            Transaction.source,
+        )
+        query = query.order_by(func.date(LineItem.date).desc(), LineItem.description.asc(), LineItem.id.asc())
+
         if offset:
             query = query.offset(offset)
         if limit is not None:
             query = query.limit(limit)
-        line_items = query.all()
-        return [serialize_line_item(li) for li in line_items]
+
+        return [
+            {
+                "id": row.id,
+                "date": serialize_datetime(row.date),
+                "payment_method": row.payment_method or "Unknown",
+                "description": row.description or "",
+                "amount": float(row.amount or 0.0),
+                "responsible_party": row.responsible_party,
+                "notes": row.notes,
+                "is_manual": row.transaction_source == "manual",
+                **({"event_id": row.event_id} if row.event_id else {}),
+            }
+            for row in query.all()
+        ]
 
 
 def get_line_item_by_id(id: str) -> Optional[Dict[str, Any]]:
@@ -88,25 +128,23 @@ def get_all_events(
     offset: int = 0,
 ) -> List[Dict[str, Any]]:
     """Get events from PostgreSQL"""
-    from datetime import datetime
+    from datetime import UTC, datetime
 
     from models.database import SessionLocal
-    from models.sql_models import Event, LineItem
+    from models.sql_models import Category, Event, EventLineItem, EventTag, LineItem, Tag
 
     with SessionLocal.begin() as db:
-        # Use subqueryload for one-to-many relationships to avoid duplicate rows
-        # joinedload is fine for many-to-one (category)
-        query = db.query(Event).options(
-            joinedload(Event.category),
-            subqueryload(Event.line_items).joinedload(LineItem.payment_method),
-            subqueryload(Event.tags),
-        )
+        query = db.query(
+            Event.id,
+            Event.date,
+            Event.description,
+            Event.is_duplicate,
+            Category.name.label("category"),
+        ).join(Category, Event.category_id == Category.id)
 
         if filters and "date" in filters:
             date_filter = filters["date"]
             if isinstance(date_filter, dict):
-                from datetime import UTC
-
                 if "$gte" in date_filter:
                     query = query.filter(Event.date >= datetime.fromtimestamp(date_filter["$gte"], UTC))
                 if "$lte" in date_filter:
@@ -117,8 +155,81 @@ def get_all_events(
             query = query.offset(offset)
         if limit is not None:
             query = query.limit(limit)
+
         events = query.all()
-        return [serialize_event(event) for event in events]
+        event_ids = [event.id for event in events]
+        if not event_ids:
+            return []
+
+        amount_rows = (
+            db.query(
+                EventLineItem.event_id,
+                func.sum(LineItem.amount).label("total_amount"),
+                func.min(LineItem.amount).label("duplicate_amount"),
+            )
+            .join(LineItem, EventLineItem.line_item_id == LineItem.id)
+            .filter(EventLineItem.event_id.in_(event_ids))
+            .group_by(EventLineItem.event_id)
+            .all()
+        )
+        amounts = {
+            row.event_id: {
+                "total": float(row.total_amount or 0.0),
+                "duplicate": float(row.duplicate_amount or 0.0),
+            }
+            for row in amount_rows
+        }
+
+        line_item_rows = (
+            db.query(EventLineItem.event_id, EventLineItem.line_item_id)
+            .filter(EventLineItem.event_id.in_(event_ids))
+            .order_by(EventLineItem.created_at.asc(), EventLineItem.line_item_id.asc())
+            .all()
+        )
+        line_items_by_event: Dict[str, List[str]] = {event_id: [] for event_id in event_ids}
+        for row in line_item_rows:
+            line_items_by_event[row.event_id].append(row.line_item_id)
+
+        tag_rows = (
+            db.query(EventTag.event_id, Tag.name)
+            .join(Tag, EventTag.tag_id == Tag.id)
+            .filter(EventTag.event_id.in_(event_ids))
+            .order_by(Tag.name.asc())
+            .all()
+        )
+        tags_by_event: Dict[str, List[str]] = {event_id: [] for event_id in event_ids}
+        for row in tag_rows:
+            tags_by_event[row.event_id].append(row.name)
+
+        return [
+            {
+                "id": event.id,
+                "date": serialize_datetime(event.date),
+                "name": event.description or "",
+                "category": event.category or "Unknown",
+                "amount": amounts.get(event.id, {}).get(
+                    "duplicate" if event.is_duplicate else "total",
+                    0.0,
+                ),
+                "line_items": line_items_by_event[event.id],
+                "tags": tags_by_event[event.id],
+                "is_duplicate_transaction": event.is_duplicate or False,
+            }
+            for event in events
+        ]
+
+
+def get_line_items_for_event(event_id: str) -> Optional[List[Dict[str, Any]]]:
+    """Get line items for an event without loading the full event graph."""
+    from models.database import SessionLocal
+    from models.sql_models import Event
+
+    with SessionLocal.begin() as db:
+        event_exists = db.query(Event.id).filter(Event.id == event_id).first()
+        if not event_exists:
+            return None
+
+    return get_all_line_items(event_id=event_id)
 
 
 def get_event_by_id(id: str) -> Optional[Dict[str, Any]]:

--- a/server/resources/event.py
+++ b/server/resources/event.py
@@ -7,7 +7,7 @@ from flask_jwt_extended import get_current_user, jwt_required
 from constants import LARGEST_EPOCH_TIME, SMALLEST_EPOCH_TIME
 from domain import get_line_item_amounts
 from helpers import html_date_to_posix
-from queries import get_all_events, get_all_line_items, get_event_by_id
+from queries import get_all_events, get_all_line_items, get_event_by_id, get_line_items_for_event
 
 logger = logging.getLogger(__name__)
 
@@ -195,11 +195,10 @@ def get_line_items_for_event_api(
     Get All Line Items Belonging To An Event
     """
     try:
-        event: Optional[Dict[str, Any]] = get_event_by_id(event_id)
-        if event is None:
+        line_items = get_line_items_for_event(event_id)
+        if line_items is None:
             logger.warning(f"Line items request for non-existent event: {event_id}")
             return jsonify({"error": "Event not found"}), 404
-        line_items: List[Dict[str, Any]] = get_all_line_items(ids=event["line_items"])
         logger.info(f"Retrieved {len(line_items)} line items for event: {event_id}")
         return jsonify({"data": line_items}), 200
     except Exception as e:

--- a/server/resources/event_hint.py
+++ b/server/resources/event_hint.py
@@ -14,7 +14,7 @@ from sqlalchemy import func
 from sqlalchemy.orm import joinedload
 
 from models.database import SessionLocal
-from models.sql_models import Category, EventHint, LineItem
+from models.sql_models import Category, EventHint, LineItem, PaymentMethod
 from utils.cel_evaluator import CELEvaluator, evaluate_hints
 from utils.id_generator import generate_id
 
@@ -34,16 +34,6 @@ def serialize_event_hint(hint: EventHint) -> dict[str, Any]:
         "prefill_category_id": hint.prefill_category_id,
         "display_order": hint.display_order,
         "is_active": hint.is_active,
-    }
-
-
-def serialize_line_item_for_cel(line_item: LineItem) -> dict[str, Any]:
-    """Convert LineItem ORM object to dict for CEL evaluation."""
-    return {
-        "description": line_item.description or "",
-        "amount": float(line_item.amount) if line_item.amount else 0.0,
-        "payment_method": line_item.payment_method.name if line_item.payment_method else "",
-        "responsible_party": line_item.responsible_party or "",
     }
 
 
@@ -248,18 +238,32 @@ def evaluate_event_hints() -> tuple[Response, int]:
         return jsonify({"data": {"suggestion": None}}), 200
 
     with SessionLocal.begin() as db:
-        # Get line items
         line_items = (
-            db.query(LineItem).options(joinedload(LineItem.payment_method)).filter(LineItem.id.in_(line_item_ids)).all()
+            db.query(
+                LineItem.description,
+                LineItem.amount,
+                LineItem.responsible_party,
+                PaymentMethod.name.label("payment_method"),
+            )
+            .join(PaymentMethod, LineItem.payment_method_id == PaymentMethod.id)
+            .filter(LineItem.id.in_(line_item_ids))
+            .all()
         )
 
         if not line_items:
             return jsonify({"data": {"suggestion": None}}), 200
 
-        # Get user's active hints in order
         hints = (
-            db.query(EventHint)
-            .options(joinedload(EventHint.prefill_category))
+            db.query(
+                EventHint.id,
+                EventHint.name,
+                EventHint.cel_expression,
+                EventHint.prefill_name,
+                EventHint.display_order,
+                EventHint.is_active,
+                Category.name.label("prefill_category"),
+            )
+            .outerjoin(Category, EventHint.prefill_category_id == Category.id)
             .filter(EventHint.user_id == user_id, EventHint.is_active == True)  # noqa: E712
             .order_by(EventHint.display_order)
             .all()
@@ -268,9 +272,27 @@ def evaluate_event_hints() -> tuple[Response, int]:
         if not hints:
             return jsonify({"data": {"suggestion": None}}), 200
 
-        # Convert to dicts for CEL evaluation
-        line_item_dicts = [serialize_line_item_for_cel(li) for li in line_items]
-        hint_dicts = [serialize_event_hint(h) for h in hints]
+        line_item_dicts = [
+            {
+                "description": row.description or "",
+                "amount": float(row.amount) if row.amount else 0.0,
+                "payment_method": row.payment_method or "",
+                "responsible_party": row.responsible_party or "",
+            }
+            for row in line_items
+        ]
+        hint_dicts = [
+            {
+                "id": row.id,
+                "name": row.name,
+                "cel_expression": row.cel_expression,
+                "prefill_name": row.prefill_name,
+                "prefill_category": row.prefill_category,
+                "display_order": row.display_order,
+                "is_active": row.is_active,
+            }
+            for row in hints
+        ]
 
         # Evaluate hints
         suggestion = evaluate_hints(hint_dicts, line_item_dicts)

--- a/server/utils/cel_evaluator.py
+++ b/server/utils/cel_evaluator.py
@@ -24,6 +24,7 @@ import logging
 import re
 from concurrent.futures import ThreadPoolExecutor
 from concurrent.futures import TimeoutError as FuturesTimeoutError
+from functools import lru_cache
 from typing import Any
 
 import celpy
@@ -52,6 +53,14 @@ LINE_ITEM_DECLS = {
     "amount": celtypes.DoubleType,
     "payment_method": celtypes.StringType,
     "responsible_party": celtypes.StringType,
+}
+
+AGGREGATE_DECLS = {
+    "sum_amount": celtypes.DoubleType,
+    "count_items": celtypes.DoubleType,
+    "avg_amount": celtypes.DoubleType,
+    "min_amount": celtypes.DoubleType,
+    "max_amount": celtypes.DoubleType,
 }
 
 
@@ -93,17 +102,39 @@ def _lowercase_string_literals(expression: str) -> str:
     return re.sub(r'"([^"]*)"', lowercase_match, expression)
 
 
+def _process_aggregate_expression(expression: str) -> str:
+    processed = expression
+    processed = re.sub(r"\bsum\s*\(\s*amount\s*\)", "sum_amount", processed)
+    processed = re.sub(r"\bcount\s*\(\s*\)", "count_items", processed)
+    processed = re.sub(r"\bavg\s*\(\s*amount\s*\)", "avg_amount", processed)
+    processed = re.sub(r"\bmin_val\s*\(\s*amount\s*\)", "min_amount", processed)
+    processed = re.sub(r"\bmax_val\s*\(\s*amount\s*\)", "max_amount", processed)
+    return re.sub(r"\b(\d+)(?!\.\d)", r"\1.0", processed)
+
+
+@lru_cache(maxsize=256)
+def _compile_single_expression(expression: str):
+    # CEL compilation is expensive; hints are reused often when the modal opens.
+    expression = _lowercase_string_literals(expression)
+    env = celpy.Environment(annotations=LINE_ITEM_DECLS)
+    ast = env.compile(expression)
+    return env.program(ast)
+
+
+@lru_cache(maxsize=128)
+def _compile_aggregate_expression(processed_expression: str):
+    env = celpy.Environment(annotations=AGGREGATE_DECLS)
+    ast = env.compile(processed_expression)
+    return env.program(ast)
+
+
 def _evaluate_single_expression(expression: str, line_items: list[dict]) -> bool:
     """
     Evaluate a single-item expression against line items.
     Returns True if ANY line item matches the expression.
     """
     try:
-        # Lowercase string literals for case-insensitive matching
-        expression = _lowercase_string_literals(expression)
-        env = celpy.Environment(annotations=LINE_ITEM_DECLS)
-        ast = env.compile(expression)
-        prgm = env.program(ast)
+        prgm = _compile_single_expression(expression)
 
         for item in line_items:
             context = _build_line_item_context(item)
@@ -126,11 +157,7 @@ def _evaluate_single_expression(expression: str, line_items: list[dict]) -> bool
 def _evaluate_single_item(expression: str, item: dict) -> bool:
     """Evaluate an expression against a single line item."""
     try:
-        # Lowercase string literals for case-insensitive matching
-        expression = _lowercase_string_literals(expression)
-        env = celpy.Environment(annotations=LINE_ITEM_DECLS)
-        ast = env.compile(expression)
-        prgm = env.program(ast)
+        prgm = _compile_single_expression(expression)
         context = _build_line_item_context(item)
         result = prgm.evaluate(context)
         return bool(result)
@@ -183,30 +210,9 @@ def _evaluate_aggregate_expression(expression: str, line_items: list[dict]) -> b
         "max_amount": celtypes.DoubleType(max_amount),
     }
 
-    # Replace aggregate function calls with variable references
-    processed = expression
-    processed = re.sub(r"\bsum\s*\(\s*amount\s*\)", "sum_amount", processed)
-    processed = re.sub(r"\bcount\s*\(\s*\)", "count_items", processed)
-    processed = re.sub(r"\bavg\s*\(\s*amount\s*\)", "avg_amount", processed)
-    processed = re.sub(r"\bmin_val\s*\(\s*amount\s*\)", "min_amount", processed)
-    processed = re.sub(r"\bmax_val\s*\(\s*amount\s*\)", "max_amount", processed)
-
-    # Also convert integer literals to floats for type consistency
-    # Match integer literals that are not part of a float (not followed by .)
-    processed = re.sub(r"\b(\d+)(?!\.\d)", r"\1.0", processed)
-
     # Evaluate the processed expression
     try:
-        decls = {
-            "sum_amount": celtypes.DoubleType,
-            "count_items": celtypes.DoubleType,
-            "avg_amount": celtypes.DoubleType,
-            "min_amount": celtypes.DoubleType,
-            "max_amount": celtypes.DoubleType,
-        }
-        env = celpy.Environment(annotations=decls)
-        ast = env.compile(processed)
-        prgm = env.program(ast)
+        prgm = _compile_aggregate_expression(_process_aggregate_expression(expression))
         result = prgm.evaluate(context)
         return bool(result)
     except Exception as e:
@@ -232,16 +238,10 @@ class CELEvaluator:
         if not line_items:
             return False
 
-        def _do_evaluate() -> bool:
-            if self.is_aggregate:
-                return _evaluate_aggregate_expression(self.expression, line_items)
-            else:
-                return _evaluate_single_expression(self.expression, line_items)
-
         # Run evaluation with timeout to prevent DoS from complex expressions
         try:
             with ThreadPoolExecutor(max_workers=1) as executor:
-                future = executor.submit(_do_evaluate)
+                future = executor.submit(self.evaluate_without_timeout, line_items)
                 return future.result(timeout=EVALUATION_TIMEOUT_SECONDS)
         except FuturesTimeoutError:
             logger.warning(
@@ -249,6 +249,11 @@ class CELEvaluator:
                 extra={"expression": self.expression[:100]},
             )
             raise CELValidationError(f"Expression evaluation timed out (max {EVALUATION_TIMEOUT_SECONDS}s)")
+
+    def evaluate_without_timeout(self, line_items: list[dict]) -> bool:
+        if self.is_aggregate:
+            return _evaluate_aggregate_expression(self.expression, line_items)
+        return _evaluate_single_expression(self.expression, line_items)
 
     @classmethod
     def validate(cls, expression: str) -> tuple[bool, str | None]:
@@ -309,27 +314,8 @@ class CELEvaluator:
     @classmethod
     def _validate_aggregate_expression(cls, expression: str) -> tuple[bool, str | None]:
         """Validate an aggregate expression."""
-        # Replace aggregate functions with variable references
-        processed = expression
-        processed = re.sub(r"\bsum\s*\(\s*amount\s*\)", "sum_amount", processed)
-        processed = re.sub(r"\bcount\s*\(\s*\)", "count_items", processed)
-        processed = re.sub(r"\bavg\s*\(\s*amount\s*\)", "avg_amount", processed)
-        processed = re.sub(r"\bmin_val\s*\(\s*amount\s*\)", "min_amount", processed)
-        processed = re.sub(r"\bmax_val\s*\(\s*amount\s*\)", "max_amount", processed)
-
-        # Convert integer literals to floats for type consistency
-        processed = re.sub(r"\b(\d+)(?!\.\d)", r"\1.0", processed)
-
         try:
-            decls = {
-                "sum_amount": celtypes.DoubleType,
-                "count_items": celtypes.DoubleType,
-                "avg_amount": celtypes.DoubleType,
-                "min_amount": celtypes.DoubleType,
-                "max_amount": celtypes.DoubleType,
-            }
-            env = celpy.Environment(annotations=decls)
-            env.compile(processed)
+            _compile_aggregate_expression(_process_aggregate_expression(expression))
             return True, None
         except Exception as e:
             return False, str(e)
@@ -348,24 +334,38 @@ def evaluate_hints(hints: list[dict], line_items: list[dict]) -> dict | None:
     Returns:
         Dict with 'name', 'category', 'matched_hint_id', 'matched_hint_name' or None.
     """
-    for hint in hints:
-        if not hint.get("is_active", True):
-            continue
 
-        try:
-            evaluator = CELEvaluator(hint["cel_expression"])
-            if evaluator.evaluate(line_items):
-                return {
-                    "name": hint["prefill_name"],
-                    "category": hint.get("prefill_category"),
-                    "matched_hint_id": hint.get("id"),
-                    "matched_hint_name": hint.get("name"),
-                }
-        except Exception as e:
-            logger.warning(
-                f"Hint evaluation failed for hint '{hint.get('name', 'unknown')}': {e}",
-                extra={"hint_id": hint.get("id"), "expression": hint.get("cel_expression", "")[:100]},
-            )
-            continue
+    # Use one timeout for the full hint scan instead of one executor per hint.
+    def _evaluate_all_hints() -> dict | None:
+        for hint in hints:
+            if not hint.get("is_active", True):
+                continue
 
-    return None
+            try:
+                evaluator = CELEvaluator(hint["cel_expression"])
+                if evaluator.evaluate_without_timeout(line_items):
+                    return {
+                        "name": hint["prefill_name"],
+                        "category": hint.get("prefill_category"),
+                        "matched_hint_id": hint.get("id"),
+                        "matched_hint_name": hint.get("name"),
+                    }
+            except Exception as e:
+                logger.warning(
+                    f"Hint evaluation failed for hint '{hint.get('name', 'unknown')}': {e}",
+                    extra={"hint_id": hint.get("id"), "expression": hint.get("cel_expression", "")[:100]},
+                )
+                continue
+
+        return None
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            future = executor.submit(_evaluate_all_hints)
+            return future.result(timeout=EVALUATION_TIMEOUT_SECONDS)
+    except FuturesTimeoutError:
+        logger.warning(
+            f"Event hint evaluation timed out after {EVALUATION_TIMEOUT_SECONDS}s",
+            extra={"hint_count": len(hints), "line_item_count": len(line_items)},
+        )
+        return None


### PR DESCRIPTION
## Summary
- Add database indexes for the highest-traffic event, line item, tag, and transaction lookup paths.
- Switch list queries to lighter-weight projections with longer cache/stale windows and keep-previous-data behavior.
- Make event creation remove reviewed line items optimistically and refresh list caches on settle.
- Reduce ORM loading overhead in event hints and event line-item lookups.
- Show fetching indicators on Events and Line Items pages during background refetches.