### PR TITLE
Close create event modal on submit

### DIFF
--- a/client/src/components/CreateEventModal.tsx
+++ b/client/src/components/CreateEventModal.tsx
@@ -81,10 +81,10 @@ function CreateEventModalContent({
       is_duplicate_transaction: isDuplicateTransaction.value,
       tags: tags.map(tag => tag.text)
     };
+    onClose();
     try {
       const response = await createEventMutation.mutateAsync(newEvent) as { name?: string };
       lineItemsDispatch({ type: "remove_line_items", lineItemIds: selectedLineItemIds });
-      onClose();
       showSuccessToast(response.name || newEvent.name, "Created Event");
     } catch (error) {
       showErrorToast(error);

--- a/client/src/components/__tests__/CreateEventModal.test.tsx
+++ b/client/src/components/__tests__/CreateEventModal.test.tsx
@@ -592,13 +592,13 @@ describe('CreateEventModal', () => {
             });
         });
 
-        it('modal closes after successful creation even if selected line items clear first', async () => {
+        it('modal closes immediately when creation starts so optimistic line item clearing cannot empty it first', async () => {
             let resolveCreateEvent: (value: { data: { name: string; success: boolean } }) => void;
             mockAxiosInstance.post.mockReturnValue(new Promise(resolve => {
                 resolveCreateEvent = resolve;
             }));
 
-            const { rerender } = render(<CreateEventModal show={true} onHide={mockOnHide} />);
+            render(<CreateEventModal show={true} onHide={mockOnHide} />);
 
             fireEvent.change(screen.getByPlaceholderText('Enter a descriptive name for this event'), {
                 target: { value: 'Test Event' },
@@ -610,15 +610,10 @@ describe('CreateEventModal', () => {
 
             await userEvent.click(screen.getByRole('button', { name: /create event/i }));
 
-            mockUseLineItems.mockReturnValue({ lineItems: [], isPending: false });
-            rerender(<CreateEventModal show={true} onHide={mockOnHide} />);
+            expect(mockOnHide).toHaveBeenCalled();
 
             await act(async () => {
                 resolveCreateEvent({ data: { name: 'Test Event', success: true } });
-            });
-
-            await waitFor(() => {
-                expect(mockOnHide).toHaveBeenCalled();
             });
         });
 


### PR DESCRIPTION
## Summary
- Close the create-event modal immediately when submission starts
- Keep the success toast and line-item cleanup after the create request resolves
- Update the regression test to assert the modal closes while the request is pending

## Root Cause
The create-event mutation optimistically removes selected line items before the request finishes. The modal form derives its key and initial values from those selected line item IDs, so the optimistic removal could remount the modal with empty fields before the delayed close ran.

## Validation
- `npm test -- CreateEventModal.test.tsx --runInBand`