### PR TITLE
Add reviewable event suggestions

### DIFF
--- a/client/src/components/LineItem.tsx
+++ b/client/src/components/LineItem.tsx
@@ -1,11 +1,10 @@
-import { MenuIcon, UserPenIcon } from "lucide-react";
+import { EyeIcon, UserPenIcon } from "lucide-react";
 import React from "react";
 import { Link } from "react-router-dom";
 import { LineItemInterface } from "../contexts/LineItemsContext";
 import { CurrencyFormatter, DateFormatter } from "../utils/formatters";
-import { Button, buttonVariants } from "./ui/button";
+import { buttonVariants } from "./ui/button";
 import { Checkbox } from "./ui/checkbox";
-import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { StatusBadge } from "./ui/status-badge";
 import { TableCell, TableRow } from "./ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
@@ -29,22 +28,22 @@ function LineItemActions({ detailPath, description }: { detailPath?: string; des
     if (!detailPath) return null;
 
     return (
-        <Popover>
-            <PopoverTrigger asChild>
-                <button
-                    type="button"
-                    className={buttonVariants({ variant: "ghost", size: "icon", className: "h-8 w-8" })}
-                    aria-label={`Actions for ${description}`}
-                >
-                    <MenuIcon />
-                </button>
-            </PopoverTrigger>
-            <PopoverContent align="end" className="w-40 p-1">
-                <Button asChild variant="ghost" size="sm" className="w-full justify-start">
-                    <Link to={detailPath}>View Details</Link>
-                </Button>
-            </PopoverContent>
-        </Popover>
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <Link
+                        to={detailPath}
+                        className={buttonVariants({ variant: "ghost", size: "icon", className: "h-8 w-8" })}
+                        aria-label={`View details for ${description}`}
+                    >
+                        <EyeIcon className="h-4 w-4" />
+                    </Link>
+                </TooltipTrigger>
+                <TooltipContent>
+                    <p>View details</p>
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
     );
 }
 

--- a/client/src/components/LineItem.tsx
+++ b/client/src/components/LineItem.tsx
@@ -52,7 +52,7 @@ function LineItemCard({ lineItem, showCheckBox, isChecked, handleToggle, amountS
 
     return (
         <div
-            className={`p-4 ${hasAttachedContent ? 'bg-primary-light/40' : 'border-b last:border-b-0'} ${isChecked ? 'bg-primary-light' : ''}`}
+            className={`p-4 ${hasAttachedContent ? 'bg-muted/30' : 'border-b last:border-b-0'} ${isChecked ? 'bg-primary-light' : ''}`}
         >
             <div className="flex items-start gap-3">
                 {showCheckBox && (
@@ -106,7 +106,7 @@ function LineItemRow({ lineItem, showCheckBox, isChecked, handleToggle, amountSt
     return (
         <TableRow
             data-state={isChecked ? 'selected' : undefined}
-            className={hasAttachedContent ? "border-b-0 bg-primary-light/40 hover:bg-primary-light/50" : undefined}
+            className={hasAttachedContent ? "border-b-0 bg-muted/30 hover:bg-muted/40" : undefined}
         >
             {showCheckBox && (
                 <TableCell className="w-12" onClick={(event) => event.stopPropagation()}>

--- a/client/src/components/LineItem.tsx
+++ b/client/src/components/LineItem.tsx
@@ -1,9 +1,11 @@
-import { UserPenIcon } from "lucide-react";
+import { MenuIcon, UserPenIcon } from "lucide-react";
 import React from "react";
-import { useNavigate } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { LineItemInterface } from "../contexts/LineItemsContext";
 import { CurrencyFormatter, DateFormatter } from "../utils/formatters";
+import { Button, buttonVariants } from "./ui/button";
 import { Checkbox } from "./ui/checkbox";
+import { Popover, PopoverContent, PopoverTrigger } from "./ui/popover";
 import { StatusBadge } from "./ui/status-badge";
 import { TableCell, TableRow } from "./ui/table";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
@@ -23,15 +25,35 @@ interface LineItemDisplayProps extends LineItemProps {
     amountStatus: 'success' | 'warning';
 }
 
+function LineItemActions({ detailPath, description }: { detailPath?: string; description: string }) {
+    if (!detailPath) return null;
+
+    return (
+        <Popover>
+            <PopoverTrigger asChild>
+                <button
+                    type="button"
+                    className={buttonVariants({ variant: "ghost", size: "icon", className: "h-8 w-8" })}
+                    aria-label={`Actions for ${description}`}
+                >
+                    <MenuIcon />
+                </button>
+            </PopoverTrigger>
+            <PopoverContent align="end" className="w-40 p-1">
+                <Button asChild variant="ghost" size="sm" className="w-full justify-start">
+                    <Link to={detailPath}>View Details</Link>
+                </Button>
+            </PopoverContent>
+        </Popover>
+    );
+}
+
 function LineItemCard({ lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath, hasAttachedContent }: LineItemDisplayProps) {
     const readableDate = DateFormatter.format(lineItem.date * 1000);
-    const navigate = useNavigate();
-    const handleCardClick = detailPath ? () => navigate(detailPath) : showCheckBox ? handleToggle : undefined;
 
     return (
         <div
-            className={`p-4 ${hasAttachedContent ? 'bg-primary-light/40' : 'border-b last:border-b-0'} ${isChecked ? 'bg-primary-light' : ''} ${detailPath ? 'cursor-pointer hover:bg-gray-50 transition-colors' : ''}`}
-            onClick={handleCardClick}
+            className={`p-4 ${hasAttachedContent ? 'bg-primary-light/40' : 'border-b last:border-b-0'} ${isChecked ? 'bg-primary-light' : ''}`}
         >
             <div className="flex items-start gap-3">
                 {showCheckBox && (
@@ -42,9 +64,12 @@ function LineItemCard({ lineItem, showCheckBox, isChecked, handleToggle, amountS
                 <div className="flex-1 min-w-0">
                     <div className="flex justify-between items-start gap-2 mb-2">
                         <span className="text-sm text-muted-foreground">{readableDate}</span>
-                        <StatusBadge status={amountStatus}>
-                            {CurrencyFormatter.format(Math.abs(lineItem.amount))}
-                        </StatusBadge>
+                        <div className="flex items-center gap-1">
+                            <StatusBadge status={amountStatus}>
+                                {CurrencyFormatter.format(Math.abs(lineItem.amount))}
+                            </StatusBadge>
+                            <LineItemActions detailPath={detailPath} description={lineItem.description} />
+                        </div>
                     </div>
                     <p className="font-medium text-foreground truncate" title={lineItem.description}>
                         {lineItem.description}
@@ -78,23 +103,11 @@ function LineItemCard({ lineItem, showCheckBox, isChecked, handleToggle, amountS
 
 function LineItemRow({ lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath, hasAttachedContent }: LineItemDisplayProps) {
     const readableDate = DateFormatter.format(lineItem.date * 1000);
-    const navigate = useNavigate();
-    const handleRowNavigation = () => {
-        if (detailPath) navigate(detailPath);
-    };
 
     return (
         <TableRow
             data-state={isChecked ? 'selected' : undefined}
-            className={`${detailPath ? "cursor-pointer" : ""} ${hasAttachedContent ? "border-b-0 bg-primary-light/40 hover:bg-primary-light/50" : ""}`}
-            onClick={detailPath ? handleRowNavigation : undefined}
-            tabIndex={detailPath ? 0 : undefined}
-            onKeyDown={detailPath ? (event) => {
-                if (event.key === "Enter" || event.key === " ") {
-                    event.preventDefault();
-                    handleRowNavigation();
-                }
-            } : undefined}
+            className={hasAttachedContent ? "border-b-0 bg-primary-light/40 hover:bg-primary-light/50" : undefined}
         >
             {showCheckBox && (
                 <TableCell className="w-12" onClick={(event) => event.stopPropagation()}>
@@ -139,6 +152,11 @@ function LineItemRow({ lineItem, showCheckBox, isChecked, handleToggle, amountSt
                     {CurrencyFormatter.format(Math.abs(lineItem.amount))}
                 </StatusBadge>
             </TableCell>
+            {detailPath && (
+                <TableCell className="w-12 text-right">
+                    <LineItemActions detailPath={detailPath} description={lineItem.description} />
+                </TableCell>
+            )}
         </TableRow>
     );
 }

--- a/client/src/components/LineItem.tsx
+++ b/client/src/components/LineItem.tsx
@@ -14,6 +14,7 @@ interface LineItemProps {
     isChecked?: boolean;
     onToggle?: (lineItemId: string) => void;
     detailPath?: string;
+    hasAttachedContent?: boolean;
 }
 
 interface LineItemDisplayProps extends LineItemProps {
@@ -22,14 +23,14 @@ interface LineItemDisplayProps extends LineItemProps {
     amountStatus: 'success' | 'warning';
 }
 
-function LineItemCard({ lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath }: LineItemDisplayProps) {
+function LineItemCard({ lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath, hasAttachedContent }: LineItemDisplayProps) {
     const readableDate = DateFormatter.format(lineItem.date * 1000);
     const navigate = useNavigate();
     const handleCardClick = detailPath ? () => navigate(detailPath) : showCheckBox ? handleToggle : undefined;
 
     return (
         <div
-            className={`p-4 border-b last:border-b-0 ${isChecked ? 'bg-primary-light' : ''} ${detailPath ? 'cursor-pointer hover:bg-gray-50 transition-colors' : ''}`}
+            className={`p-4 ${hasAttachedContent ? 'bg-primary-light/40' : 'border-b last:border-b-0'} ${isChecked ? 'bg-primary-light' : ''} ${detailPath ? 'cursor-pointer hover:bg-gray-50 transition-colors' : ''}`}
             onClick={handleCardClick}
         >
             <div className="flex items-start gap-3">
@@ -75,7 +76,7 @@ function LineItemCard({ lineItem, showCheckBox, isChecked, handleToggle, amountS
     );
 }
 
-function LineItemRow({ lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath }: LineItemDisplayProps) {
+function LineItemRow({ lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath, hasAttachedContent }: LineItemDisplayProps) {
     const readableDate = DateFormatter.format(lineItem.date * 1000);
     const navigate = useNavigate();
     const handleRowNavigation = () => {
@@ -85,7 +86,7 @@ function LineItemRow({ lineItem, showCheckBox, isChecked, handleToggle, amountSt
     return (
         <TableRow
             data-state={isChecked ? 'selected' : undefined}
-            className={detailPath ? "cursor-pointer" : undefined}
+            className={`${detailPath ? "cursor-pointer" : ""} ${hasAttachedContent ? "border-b-0 bg-primary-light/40 hover:bg-primary-light/50" : ""}`}
             onClick={detailPath ? handleRowNavigation : undefined}
             tabIndex={detailPath ? 0 : undefined}
             onKeyDown={detailPath ? (event) => {
@@ -142,10 +143,10 @@ function LineItemRow({ lineItem, showCheckBox, isChecked, handleToggle, amountSt
     );
 }
 
-const LineItem = React.memo(function LineItem({ lineItem, showCheckBox, isChecked = false, onToggle, detailPath }: LineItemProps) {
+const LineItem = React.memo(function LineItem({ lineItem, showCheckBox, isChecked = false, onToggle, detailPath, hasAttachedContent }: LineItemProps) {
     const amountStatus: 'success' | 'warning' = lineItem.amount < 0 ? 'success' : 'warning';
     const handleToggle = onToggle ? () => onToggle(lineItem.id) : () => {};
-    const props = { lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath };
+    const props = { lineItem, showCheckBox, isChecked, handleToggle, amountStatus, detailPath, hasAttachedContent };
     return <LineItemRow {...props} />;
 });
 

--- a/client/src/components/__tests__/LineItem.test.tsx
+++ b/client/src/components/__tests__/LineItem.test.tsx
@@ -85,14 +85,14 @@ describe('LineItem', () => {
             expect(cells[4]).toHaveTextContent('$50.00');
         });
 
-        it('renders the details menu in a dedicated actions cell', () => {
+        it('renders the view details action in a dedicated actions cell', () => {
             render(
                 <table><tbody><LineItem lineItem={mockLineItem} detailPath="/line_items/1" /></tbody></table>
             );
 
             const cells = screen.getAllByRole('cell');
             const amountCell = screen.getByText('$50.00').closest('td');
-            const actionsCell = screen.getByRole('button', { name: 'Actions for Test transaction' }).closest('td');
+            const actionsCell = screen.getByRole('link', { name: 'View details for Test transaction' }).closest('td');
 
             expect(cells).toHaveLength(6);
             expect(amountCell).not.toBe(actionsCell);
@@ -168,16 +168,12 @@ describe('LineItem', () => {
             expect(checkbox).toHaveFocus();
         });
 
-        it('view details menu opens the detail path', async () => {
+        it('view details action opens the detail path', async () => {
             render(
                 <table><tbody><LineItem lineItem={mockLineItem} detailPath="/line_items/1" /></tbody></table>
             );
 
-            const actionsButton = screen.getByRole('button', { name: 'Actions for Test transaction' });
-            expect(actionsButton).toHaveAttribute('aria-expanded', 'false');
-            await userEvent.click(actionsButton);
-            expect(actionsButton).toHaveAttribute('aria-expanded', 'true');
-            await userEvent.click(await screen.findByRole('link', { name: 'View Details' }));
+            await userEvent.click(screen.getByRole('link', { name: 'View details for Test transaction' }));
 
             await waitFor(() => {
                 expect(window.location.pathname).toBe('/line_items/1');
@@ -196,7 +192,7 @@ describe('LineItem', () => {
             expect(window.location.pathname).toBe('/');
         });
 
-        it('mobile cards expose details through the actions menu', async () => {
+        it('mobile cards expose a direct view details action', async () => {
             render(
                 <LineItemCard
                     lineItem={mockLineItem}
@@ -207,8 +203,7 @@ describe('LineItem', () => {
                 />
             );
 
-            await userEvent.click(screen.getByRole('button', { name: 'Actions for Test transaction' }));
-            await userEvent.click(await screen.findByRole('link', { name: 'View Details' }));
+            await userEvent.click(screen.getByRole('link', { name: 'View details for Test transaction' }));
 
             await waitFor(() => {
                 expect(window.location.pathname).toBe('/line_items/1');

--- a/client/src/components/__tests__/LineItem.test.tsx
+++ b/client/src/components/__tests__/LineItem.test.tsx
@@ -1,7 +1,7 @@
 import userEvent from '@testing-library/user-event';
 import React from 'react';
-import { mockLineItem, render, screen, waitFor } from '../../utils/test-utils';
-import LineItem from '../LineItem';
+import { fireEvent, mockLineItem, render, screen, waitFor } from '../../utils/test-utils';
+import LineItem, { LineItemCard } from '../LineItem';
 
 describe('LineItem', () => {
     beforeEach(() => {
@@ -84,6 +84,21 @@ describe('LineItem', () => {
             expect(cells[3]).toHaveTextContent('Test Store');
             expect(cells[4]).toHaveTextContent('$50.00');
         });
+
+        it('renders the details menu in a dedicated actions cell', () => {
+            render(
+                <table><tbody><LineItem lineItem={mockLineItem} detailPath="/line_items/1" /></tbody></table>
+            );
+
+            const cells = screen.getAllByRole('cell');
+            const amountCell = screen.getByText('$50.00').closest('td');
+            const actionsCell = screen.getByRole('button', { name: 'Actions for Test transaction' }).closest('td');
+
+            expect(cells).toHaveLength(6);
+            expect(amountCell).not.toBe(actionsCell);
+            expect(cells[4]).toBe(amountCell);
+            expect(cells[5]).toBe(actionsCell);
+        });
     });
 
     describe('Checkbox State Management', () => {
@@ -153,12 +168,47 @@ describe('LineItem', () => {
             expect(checkbox).toHaveFocus();
         });
 
-        it('row opens detail path when detailPath is provided', async () => {
+        it('view details menu opens the detail path', async () => {
             render(
                 <table><tbody><LineItem lineItem={mockLineItem} detailPath="/line_items/1" /></tbody></table>
             );
 
-            await userEvent.click(screen.getByText('Test transaction'));
+            const actionsButton = screen.getByRole('button', { name: 'Actions for Test transaction' });
+            expect(actionsButton).toHaveAttribute('aria-expanded', 'false');
+            await userEvent.click(actionsButton);
+            expect(actionsButton).toHaveAttribute('aria-expanded', 'true');
+            await userEvent.click(await screen.findByRole('link', { name: 'View Details' }));
+
+            await waitFor(() => {
+                expect(window.location.pathname).toBe('/line_items/1');
+            });
+        });
+
+        it('clicking or pressing Enter on a row does not open details', async () => {
+            render(
+                <table><tbody><LineItem lineItem={mockLineItem} detailPath="/line_items/1" /></tbody></table>
+            );
+
+            const description = screen.getByText('Test transaction');
+            await userEvent.click(description);
+            fireEvent.keyDown(description, { key: 'Enter' });
+
+            expect(window.location.pathname).toBe('/');
+        });
+
+        it('mobile cards expose details through the actions menu', async () => {
+            render(
+                <LineItemCard
+                    lineItem={mockLineItem}
+                    isChecked={false}
+                    handleToggle={() => { }}
+                    amountStatus="warning"
+                    detailPath="/line_items/1"
+                />
+            );
+
+            await userEvent.click(screen.getByRole('button', { name: 'Actions for Test transaction' }));
+            await userEvent.click(await screen.findByRole('link', { name: 'View Details' }));
 
             await waitFor(() => {
                 expect(window.location.pathname).toBe('/line_items/1');

--- a/client/src/contexts/LineItemsContext.tsx
+++ b/client/src/contexts/LineItemsContext.tsx
@@ -19,12 +19,20 @@ export interface LineItemInterface {
     event_id?: string;
     is_manual?: boolean; // Whether this transaction was manually created vs synced from API (defaults to false)
     isSelected?: boolean; // Optional if not used in this context
+    event_suggestion?: {
+        id: string;
+        name: string;
+        category_id: string;
+        category: string;
+        matched_hint_name: string | null;
+    } | null;
 }
 
 type Action =
     | { type: 'populate_line_items'; fetchedLineItems: LineItemInterface[] }
     | { type: 'toggle_line_item_select'; lineItemId: string }
-    | { type: 'remove_line_items'; lineItemIds: string[] };
+    | { type: 'remove_line_items'; lineItemIds: string[] }
+    | { type: 'dismiss_event_suggestion'; lineItemId: string };
 
 interface LineItemsContextValue {
     lineItems: LineItemInterface[];
@@ -61,6 +69,11 @@ function lineItemsReducer(lineItems: LineItemInterface[], action: Action) {
         }
         case "remove_line_items": {
             return lineItems.filter(lineItem => !action.lineItemIds.includes(lineItem.id))
+        }
+        case "dismiss_event_suggestion": {
+            return lineItems.map(lineItem => lineItem.id === action.lineItemId
+                ? { ...lineItem, event_suggestion: null }
+                : lineItem)
         }
         default: {
             // Use `never` to signal an unreachable case

--- a/client/src/hooks/__tests__/useApi.test.tsx
+++ b/client/src/hooks/__tests__/useApi.test.tsx
@@ -22,6 +22,7 @@ const mockDelete = axiosInstance.delete as jest.Mock;
 
 import {
     queryKeys,
+    useAcceptEventSuggestion,
     useCreateEvent,
     useCreateManualTransaction,
     useCreateSplitwiseExpense,
@@ -36,6 +37,7 @@ import {
     useLogout,
     useMonthlyBreakdown,
     usePaymentMethods,
+    useRejectEventSuggestion,
     useSplitwiseCurrentUser,
     useSplitwiseFriends,
     useUpdateLineItem,
@@ -543,6 +545,44 @@ describe('useApi hooks', () => {
             expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['lineItems'], refetchType: 'none' });
             expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['monthlyBreakdown'], refetchType: 'none' });
             expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['tags'], refetchType: 'none' });
+        });
+    });
+
+    describe('event suggestion mutations', () => {
+        it('accepts a suggestion with the edited name and invalidates event data', async () => {
+            mockPost.mockResolvedValue({ data: { id: 'evt-1', name: 'Edited title' } });
+            const queryClient = createTestQueryClient();
+            const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+            );
+            const { result } = renderHook(() => useAcceptEventSuggestion(), { wrapper });
+
+            await act(async () => {
+                await result.current.mutateAsync({ suggestionId: 'es-1', name: 'Edited title' });
+            });
+
+            expect(mockPost).toHaveBeenCalledWith('api/event-suggestions/es-1/accept', { name: 'Edited title' });
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['events'] });
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['lineItems'] });
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['monthlyBreakdown'] });
+        });
+
+        it('rejects a suggestion and invalidates line items', async () => {
+            mockPost.mockResolvedValue({});
+            const queryClient = createTestQueryClient();
+            const invalidateSpy = jest.spyOn(queryClient, 'invalidateQueries');
+            const wrapper = ({ children }: { children: React.ReactNode }) => (
+                <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+            );
+            const { result } = renderHook(() => useRejectEventSuggestion(), { wrapper });
+
+            await act(async () => {
+                await result.current.mutateAsync('es-1');
+            });
+
+            expect(mockPost).toHaveBeenCalledWith('api/event-suggestions/es-1/reject');
+            expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['lineItems'] });
         });
     });
 

--- a/client/src/hooks/useApi.ts
+++ b/client/src/hooks/useApi.ts
@@ -524,6 +524,40 @@ export interface EventHintSuggestion {
   matched_hint_name: string;
 }
 
+interface AcceptEventSuggestionData {
+  suggestionId: string;
+  name: string;
+}
+
+export function useAcceptEventSuggestion(): UseMutationResult<EventInterface, Error, AcceptEventSuggestionData> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ suggestionId, name }: AcceptEventSuggestionData) => {
+      const response = await axiosInstance.post(`api/event-suggestions/${suggestionId}/accept`, { name });
+      return response.data as EventInterface;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['events'] });
+      queryClient.invalidateQueries({ queryKey: ['lineItems'] });
+      queryClient.invalidateQueries({ queryKey: queryKeys.monthlyBreakdown() });
+    },
+  });
+}
+
+export function useRejectEventSuggestion(): UseMutationResult<void, Error, string> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (suggestionId: string) => {
+      await axiosInstance.post(`api/event-suggestions/${suggestionId}/reject`);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['lineItems'] });
+    },
+  });
+}
+
 export type CategoryOption = components['schemas']['CategoryListResponse.CategoryOut'];
 
 export function useEventHints(): UseQueryResult<EventHint[]> {

--- a/client/src/pages/EventDetailPage.tsx
+++ b/client/src/pages/EventDetailPage.tsx
@@ -76,6 +76,7 @@ function LinkedLineItems({ lineItems, isLoading, error, returnTo }: { lineItems:
                             <TableHead>Description</TableHead>
                             <TableHead>Party</TableHead>
                             <TableHead className="text-right">Amount</TableHead>
+                            <TableHead className="w-12 text-right">Actions</TableHead>
                         </TableRow>
                     </TableHeader>
                     <TableBody>

--- a/client/src/pages/LineItemsPage.tsx
+++ b/client/src/pages/LineItemsPage.tsx
@@ -83,18 +83,19 @@ export default function LineItemsPage() {
                                 <TableHead>Description</TableHead>
                                 <TableHead>Party</TableHead>
                                 <TableHead className="text-right">Amount</TableHead>
+                                <TableHead className="w-12 text-right">Actions</TableHead>
                             </TableRow>
                         </TableHeader>
                         <TableBody>
                             {isLoading ? (
                                 <TableRow>
-                                    <TableCell colSpan={5} className="text-center py-8">
+                                    <TableCell colSpan={6} className="text-center py-8">
                                         <Spinner size="md" className="text-muted-foreground mx-auto" />
                                     </TableCell>
                                 </TableRow>
                             ) : error ? (
                                 <TableRow>
-                                    <TableCell colSpan={5} className="text-center text-destructive">
+                                    <TableCell colSpan={6} className="text-center text-destructive">
                                         Error loading line items. Please try again.
                                     </TableCell>
                                 </TableRow>
@@ -108,7 +109,7 @@ export default function LineItemsPage() {
                                 ))
                             ) : (
                                 <TableRow>
-                                    <TableCell colSpan={5} className="text-center text-muted-foreground">
+                                    <TableCell colSpan={6} className="text-center text-muted-foreground">
                                         No Line Items found
                                     </TableCell>
                                 </TableRow>

--- a/client/src/pages/LineItemsToReviewPage.tsx
+++ b/client/src/pages/LineItemsToReviewPage.tsx
@@ -1,8 +1,11 @@
 import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
 import { Spinner } from "@/components/ui/spinner";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { CurrencyFormatter } from "@/utils/formatters";
 import React, { useCallback, useEffect, useState } from "react";
+import { CornerDownRight } from "lucide-react";
 import CreateEventModal from "../components/CreateEventModal";
 import CreateManualTransactionModal from "../components/CreateManualTransactionModal";
 import CreateSplitwiseExpenseModal from "../components/CreateSplitwiseExpenseModal";
@@ -10,6 +13,93 @@ import LineItem, { LineItemCard } from "../components/LineItem";
 import { PageContainer, PageHeader } from "../components/ui/layout";
 import { Body, H1 } from "../components/ui/typography";
 import { LineItemInterface, useLineItems, useLineItemsDispatch } from "../contexts/LineItemsContext";
+import { useAcceptEventSuggestion, useRejectEventSuggestion } from "../hooks/useApi";
+import { showErrorToast, showSuccessToast } from "../utils/toast-helpers";
+
+function EventSuggestionReview({ lineItem, mobile = false }: { lineItem: LineItemInterface; mobile?: boolean }) {
+    const suggestion = lineItem.event_suggestion;
+    const [name, setName] = useState(suggestion?.name ?? "");
+    const acceptSuggestion = useAcceptEventSuggestion();
+    const rejectSuggestion = useRejectEventSuggestion();
+    const lineItemsDispatch = useLineItemsDispatch();
+
+    if (!suggestion) return null;
+
+    const accept = async () => {
+        try {
+            const event = await acceptSuggestion.mutateAsync({ suggestionId: suggestion.id, name: name.trim() });
+            lineItemsDispatch({ type: "remove_line_items", lineItemIds: [lineItem.id] });
+            showSuccessToast(event.name, "Created Event");
+        } catch (error) {
+            showErrorToast(error);
+        }
+    };
+
+    const reject = async () => {
+        try {
+            await rejectSuggestion.mutateAsync(suggestion.id);
+            lineItemsDispatch({ type: "dismiss_event_suggestion", lineItemId: lineItem.id });
+        } catch (error) {
+            showErrorToast(error);
+        }
+    };
+
+    const isPending = acceptSuggestion.isPending || rejectSuggestion.isPending;
+    const content = (
+        <div className="flex items-start gap-3 border-l-2 border-primary/30 pl-3 md:pl-4">
+            <CornerDownRight className="mt-0.5 h-4 w-4 shrink-0 text-primary" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+                <div>
+                    <p className="text-sm font-medium text-foreground">Create an event for this line item</p>
+                    <p className="text-xs text-muted-foreground">
+                        {lineItem.description} · {CurrencyFormatter.format(Math.abs(lineItem.amount))}
+                    </p>
+                </div>
+                <div className={`mt-2 flex ${mobile ? "flex-col" : "items-center"} gap-2`}>
+                    <div className={`flex min-w-0 flex-1 ${mobile ? "flex-col items-start" : "items-center"} gap-2`}>
+                        <Input
+                            aria-label={`Suggested event title for ${lineItem.description}`}
+                            value={name}
+                            onChange={(event) => setName(event.target.value)}
+                            onKeyDown={(event) => {
+                                if (event.key === "Enter" && name.trim() && !isPending) void accept();
+                            }}
+                            className="h-9 bg-white"
+                        />
+                        <Badge className="shrink-0 bg-white text-foreground border hover:bg-white">
+                            Category: {suggestion.category}
+                        </Badge>
+                    </div>
+                    <div className="flex shrink-0 gap-2">
+                        <Button
+                            aria-label={`Create event from ${lineItem.description}`}
+                            size="sm"
+                            onClick={() => void accept()}
+                            disabled={!name.trim() || isPending}
+                        >
+                            {acceptSuggestion.isPending ? <Spinner size="sm" /> : "Create event"}
+                        </Button>
+                        <Button
+                            aria-label={`Dismiss suggestion for ${lineItem.description}`}
+                            size="sm"
+                            variant="secondary"
+                            onClick={() => void reject()}
+                            disabled={isPending}
+                        >
+                            Dismiss
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+
+    return mobile ? content : (
+        <TableRow data-testid={`event-suggestion-${lineItem.id}`} className="bg-primary-light/40 hover:bg-primary-light/40">
+            <TableCell colSpan={6} className="px-3 pt-0 pb-4 md:px-6 md:pt-0">{content}</TableCell>
+        </TableRow>
+    );
+}
 
 const MobileLineItemCard = React.memo(function MobileLineItemCard({ lineItem, isChecked, onToggle }: { lineItem: LineItemInterface; isChecked: boolean; onToggle: (lineItemId: string) => void }) {
     const amountStatus: 'success' | 'warning' = lineItem.amount < 0 ? 'success' : 'warning';
@@ -23,6 +113,7 @@ const MobileLineItemCard = React.memo(function MobileLineItemCard({ lineItem, is
             handleToggle={() => onToggle(lineItem.id)}
             amountStatus={amountStatus}
             detailPath={detailPath}
+            hasAttachedContent={!!lineItem.event_suggestion}
         />
     );
 });
@@ -74,12 +165,21 @@ export default function LineItemsToReviewPage() {
                         </div>
                     ) : lineItems && lineItems.length > 0 ? (
                         lineItems.map(lineItem => (
-                            <MobileLineItemCard
+                            <div
                                 key={lineItem.id}
-                                lineItem={lineItem}
-                                isChecked={!!lineItem.isSelected}
-                                onToggle={handleToggle}
-                            />
+                                className={lineItem.event_suggestion ? "m-2 overflow-hidden rounded-lg border border-primary/20 bg-primary-light/40" : undefined}
+                            >
+                                <MobileLineItemCard
+                                    lineItem={lineItem}
+                                    isChecked={!!lineItem.isSelected}
+                                    onToggle={handleToggle}
+                                />
+                                {lineItem.event_suggestion && (
+                                    <div className="border-t border-primary/15 p-3">
+                                        <EventSuggestionReview key={lineItem.event_suggestion.id} lineItem={lineItem} mobile />
+                                    </div>
+                                )}
+                            </div>
                         ))
                     ) : (
                         <div className="p-4 text-center text-muted-foreground">
@@ -109,16 +209,21 @@ export default function LineItemsToReviewPage() {
                                     </TableCell>
                                 </TableRow>
                             ) : lineItems && lineItems.length > 0 ? (
-                                lineItems.map(lineItem =>
-                                    <LineItem
-                                        key={lineItem.id}
-                                        lineItem={lineItem}
-                                        showCheckBox={true}
-                                        isChecked={!!lineItem.isSelected}
-                                        onToggle={handleToggle}
-                                        detailPath={`/line_items/${lineItem.id}?returnTo=${encodeURIComponent("/")}`}
-                                    />
-                                )
+                                lineItems.map(lineItem => (
+                                    <React.Fragment key={lineItem.id}>
+                                        <LineItem
+                                            lineItem={lineItem}
+                                            showCheckBox={true}
+                                            isChecked={!!lineItem.isSelected}
+                                            onToggle={handleToggle}
+                                            detailPath={`/line_items/${lineItem.id}?returnTo=${encodeURIComponent("/")}`}
+                                            hasAttachedContent={!!lineItem.event_suggestion}
+                                        />
+                                        {lineItem.event_suggestion && (
+                                            <EventSuggestionReview key={lineItem.event_suggestion.id} lineItem={lineItem} />
+                                        )}
+                                    </React.Fragment>
+                                ))
                             ) : (
                                 <TableRow>
                                     <TableCell colSpan={6} className="text-center text-muted-foreground">

--- a/client/src/pages/LineItemsToReviewPage.tsx
+++ b/client/src/pages/LineItemsToReviewPage.tsx
@@ -96,7 +96,7 @@ function EventSuggestionReview({ lineItem, mobile = false }: { lineItem: LineIte
 
     return mobile ? content : (
         <TableRow data-testid={`event-suggestion-${lineItem.id}`} className="bg-primary-light/40 hover:bg-primary-light/40">
-            <TableCell colSpan={6} className="px-3 pt-0 pb-4 md:px-6 md:pt-0">{content}</TableCell>
+            <TableCell colSpan={7} className="px-3 pt-0 pb-4 md:px-6 md:pt-0">{content}</TableCell>
         </TableRow>
     );
 }
@@ -133,17 +133,27 @@ export default function LineItemsToReviewPage() {
     }, [lineItemsDispatch]);
 
     const handleKeyDown = useCallback((event) => {
-        if (event.key === 'Enter' && selectedLineItems.length > 0 && !eventModalShow && !manualTransactionModalShow) {
+        const target = event.target;
+        const targetElement = target instanceof HTMLElement ? target : null;
+        const isCheckbox = !!targetElement?.closest("[role='checkbox']");
+        const isInteractiveTarget = !isCheckbox
+            && !!targetElement?.closest("button, input, a, [role='menuitem'], [contenteditable='true']");
+
+        if (event.key === 'Enter' && !event.defaultPrevented && !isInteractiveTarget && selectedLineItems.length > 0 && !eventModalShow && !manualTransactionModalShow) {
+            // Radix renders the checkbox as a button. Prevent its native Enter
+            // activation from toggling the selection while opening the modal.
+            if (isCheckbox) event.preventDefault();
             setEventModalShow(true);
         }
     }, [selectedLineItems.length, eventModalShow, manualTransactionModalShow]);
 
     useEffect(() => {
-        document.addEventListener('keydown', handleKeyDown);
+        // Capture the shortcut before Radix Checkbox consumes Enter.
+        document.addEventListener('keydown', handleKeyDown, true);
 
         // Cleanup the event listener on component unmount
         return () => {
-            document.removeEventListener('keydown', handleKeyDown);
+            document.removeEventListener('keydown', handleKeyDown, true);
         };
     }, [handleKeyDown]); // Re-run effect if handleKeyDown changes
 
@@ -199,12 +209,13 @@ export default function LineItemsToReviewPage() {
                                 <TableHead>Description</TableHead>
                                 <TableHead>Party</TableHead>
                                 <TableHead className="text-right">Amount</TableHead>
+                                <TableHead className="w-12 text-right">Actions</TableHead>
                             </TableRow>
                         </TableHeader>
                         <TableBody>
                             {isPending ? (
                                 <TableRow>
-                                    <TableCell colSpan={6} className="text-center py-8">
+                                    <TableCell colSpan={7} className="text-center py-8">
                                         <Spinner size="md" className="text-muted-foreground mx-auto" />
                                     </TableCell>
                                 </TableRow>
@@ -226,7 +237,7 @@ export default function LineItemsToReviewPage() {
                                 ))
                             ) : (
                                 <TableRow>
-                                    <TableCell colSpan={6} className="text-center text-muted-foreground">
+                                    <TableCell colSpan={7} className="text-center text-muted-foreground">
                                         No line items to review
                                     </TableCell>
                                 </TableRow>

--- a/client/src/pages/LineItemsToReviewPage.tsx
+++ b/client/src/pages/LineItemsToReviewPage.tsx
@@ -51,9 +51,6 @@ function EventSuggestionReview({ lineItem, mobile = false }: { lineItem: LineIte
             <div className="min-w-0 flex-1">
                 <div>
                     <p className="text-sm font-medium text-foreground">Create an event for this line item</p>
-                    <p className="text-xs text-muted-foreground">
-                        {lineItem.description} · {CurrencyFormatter.format(Math.abs(lineItem.amount))}
-                    </p>
                 </div>
                 <div className={`mt-2 flex ${mobile ? "flex-col" : "items-center"} gap-2`}>
                     <div className={`flex min-w-0 flex-1 ${mobile ? "flex-col items-start" : "items-center"} gap-2`}>
@@ -95,7 +92,7 @@ function EventSuggestionReview({ lineItem, mobile = false }: { lineItem: LineIte
     );
 
     return mobile ? content : (
-        <TableRow data-testid={`event-suggestion-${lineItem.id}`} className="bg-primary-light/40 hover:bg-primary-light/40">
+        <TableRow data-testid={`event-suggestion-${lineItem.id}`} className="bg-muted/30 hover:bg-muted/30">
             <TableCell colSpan={7} className="px-3 pt-0 pb-4 md:px-6 md:pt-0">{content}</TableCell>
         </TableRow>
     );
@@ -177,7 +174,7 @@ export default function LineItemsToReviewPage() {
                         lineItems.map(lineItem => (
                             <div
                                 key={lineItem.id}
-                                className={lineItem.event_suggestion ? "m-2 overflow-hidden rounded-lg border border-primary/20 bg-primary-light/40" : undefined}
+                                className={lineItem.event_suggestion ? "m-2 overflow-hidden rounded-lg border border-primary/20 bg-muted/30" : undefined}
                             >
                                 <MobileLineItemCard
                                     lineItem={lineItem}

--- a/client/src/pages/__tests__/LineItemsPage.test.tsx
+++ b/client/src/pages/__tests__/LineItemsPage.test.tsx
@@ -132,6 +132,7 @@ describe('LineItemsPage', () => {
                 expect(screen.getByText('Description')).toBeInTheDocument();
                 expect(screen.getByText('Party')).toBeInTheDocument();
                 expect(screen.getByText('Amount')).toBeInTheDocument();
+                expect(screen.getByText('Actions')).toBeInTheDocument();
             });
         });
 
@@ -362,7 +363,7 @@ describe('LineItemsPage', () => {
 
             await waitFor(() => {
                 const headers = screen.getAllByRole('columnheader');
-                expect(headers).toHaveLength(5); // Date, Payment Method, Description, Name, Amount
+                expect(headers).toHaveLength(6); // Date, Payment Method, Description, Name, Amount, Actions
             });
         });
     });

--- a/client/src/pages/__tests__/LineItemsToReviewPage.test.tsx
+++ b/client/src/pages/__tests__/LineItemsToReviewPage.test.tsx
@@ -222,7 +222,6 @@ describe('LineItemsToReviewPage', () => {
             render(<LineItemsToReviewPage />);
 
             expect(screen.getAllByText('Create an event for this line item')).toHaveLength(2);
-            expect(screen.getAllByText('Test transaction 1 · $50.00')).toHaveLength(2);
             expect(screen.getAllByText('Category: Subscription')).toHaveLength(2);
         });
     });

--- a/client/src/pages/__tests__/LineItemsToReviewPage.test.tsx
+++ b/client/src/pages/__tests__/LineItemsToReviewPage.test.tsx
@@ -7,9 +7,21 @@ import LineItemsToReviewPage from '../LineItemsToReviewPage';
 
 // Mock the context
 const mockDispatch = jest.fn();
+const mockAcceptSuggestion = jest.fn();
+const mockRejectSuggestion = jest.fn();
 jest.mock('../../contexts/LineItemsContext', () => ({
     useLineItems: jest.fn(),
     useLineItemsDispatch: jest.fn(() => mockDispatch),
+}));
+jest.mock('../../hooks/useApi', () => ({
+    useAcceptEventSuggestion: () => ({
+        mutateAsync: mockAcceptSuggestion,
+        isPending: false,
+    }),
+    useRejectEventSuggestion: () => ({
+        mutateAsync: mockRejectSuggestion,
+        isPending: false,
+    }),
 }));
 
 // Mock the components
@@ -159,7 +171,60 @@ const mockLineItemsWithSelection = [
 describe('LineItemsToReviewPage', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        mockAcceptSuggestion.mockResolvedValue({ name: 'Spotify' });
+        mockRejectSuggestion.mockResolvedValue(undefined);
         mockUseLineItems.mockReturnValue({ lineItems: mockLineItems, isPending: false });
+    });
+
+    describe('Event suggestions', () => {
+        const suggestedLineItem = {
+            ...mockLineItems[0],
+            event_suggestion: {
+                id: 'es_1',
+                name: 'Spotify',
+                category_id: 'cat_subscription',
+                category: 'Subscription',
+                matched_hint_name: 'Spotify purchases',
+            },
+        };
+
+        it('accepts a suggestion with an edited event title', async () => {
+            mockAcceptSuggestion.mockResolvedValue({ name: 'Monthly Spotify' });
+            mockUseLineItems.mockReturnValue({ lineItems: [suggestedLineItem], isPending: false });
+            render(<LineItemsToReviewPage />);
+
+            const titleInputs = screen.getAllByRole('textbox', { name: /suggested event title/i });
+            await userEvent.clear(titleInputs[1]);
+            await userEvent.type(titleInputs[1], 'Monthly Spotify');
+            await userEvent.click(screen.getAllByRole('button', { name: /create event from/i })[1]);
+
+            await waitFor(() => {
+                expect(mockAcceptSuggestion).toHaveBeenCalledWith({ suggestionId: 'es_1', name: 'Monthly Spotify' });
+                expect(mockDispatch).toHaveBeenCalledWith({ type: 'remove_line_items', lineItemIds: ['1'] });
+            });
+        });
+
+        it('rejects a suggestion without removing the line item', async () => {
+            mockUseLineItems.mockReturnValue({ lineItems: [suggestedLineItem], isPending: false });
+            render(<LineItemsToReviewPage />);
+
+            await userEvent.click(screen.getAllByRole('button', { name: /dismiss suggestion/i })[1]);
+
+            await waitFor(() => {
+                expect(mockRejectSuggestion).toHaveBeenCalledWith('es_1');
+                expect(mockDispatch).toHaveBeenCalledWith({ type: 'dismiss_event_suggestion', lineItemId: '1' });
+            });
+            expect(mockDispatch).not.toHaveBeenCalledWith({ type: 'remove_line_items', lineItemIds: ['1'] });
+        });
+
+        it('explicitly connects the suggestion to its line item', () => {
+            mockUseLineItems.mockReturnValue({ lineItems: [suggestedLineItem], isPending: false });
+            render(<LineItemsToReviewPage />);
+
+            expect(screen.getAllByText('Create an event for this line item')).toHaveLength(2);
+            expect(screen.getAllByText('Test transaction 1 · $50.00')).toHaveLength(2);
+            expect(screen.getAllByText('Category: Subscription')).toHaveLength(2);
+        });
     });
 
     describe('Rendering', () => {

--- a/client/src/pages/__tests__/LineItemsToReviewPage.test.tsx
+++ b/client/src/pages/__tests__/LineItemsToReviewPage.test.tsx
@@ -75,7 +75,7 @@ jest.mock('../../components/LineItem', () => {
     const MockLineItem = function ({ lineItem, showCheckBox, onToggle }: MockLineItemProps) {
         return (
             <tr data-testid={`line-item-${lineItem.id}`}>
-                <td>{showCheckBox ? <button data-testid={`toggle-${lineItem.id}`} onClick={() => onToggle?.(lineItem.id)}>Checkbox</button> : 'No Checkbox'}</td>
+                <td>{showCheckBox ? <button role="checkbox" aria-checked="false" data-testid={`toggle-${lineItem.id}`} onKeyDown={(event) => event.preventDefault()} onClick={() => onToggle?.(lineItem.id)}>Checkbox</button> : 'No Checkbox'}</td>
                 <td>{new Date(lineItem.date * 1000).toLocaleDateString()}</td>
                 <td>{lineItem.payment_method || ''}</td>
                 <td>{lineItem.description || ''}</td>
@@ -242,6 +242,7 @@ describe('LineItemsToReviewPage', () => {
             expect(screen.getByText('Description')).toBeInTheDocument();
             expect(screen.getByText('Party')).toBeInTheDocument();
             expect(screen.getByText('Amount')).toBeInTheDocument();
+            expect(screen.getByText('Actions')).toBeInTheDocument();
         });
 
         it('renders line items in the table', () => {
@@ -413,6 +414,19 @@ describe('LineItemsToReviewPage', () => {
             });
         });
 
+        it('opens event modal when Enter is pressed after selecting a checkbox', async () => {
+            mockUseLineItems.mockReturnValue({ lineItems: mockLineItemsWithSelection, isPending: false });
+            render(<LineItemsToReviewPage />);
+
+            const checkbox = screen.getByTestId('toggle-1');
+            checkbox.focus();
+            fireEvent.keyDown(checkbox, { key: 'Enter' });
+
+            await waitFor(() => {
+                expect(screen.getByTestId('event-modal')).toBeInTheDocument();
+            });
+        });
+
         it('does not open event modal for other key presses', async () => {
             render(<LineItemsToReviewPage />);
 
@@ -480,11 +494,11 @@ describe('LineItemsToReviewPage', () => {
 
             const { unmount } = render(<LineItemsToReviewPage />);
 
-            expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+            expect(addEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
 
             unmount();
 
-            expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+            expect(removeEventListenerSpy).toHaveBeenCalledWith('keydown', expect.any(Function), true);
 
             addEventListenerSpy.mockRestore();
             removeEventListenerSpy.mockRestore();

--- a/server/alembic/versions/a7b8c9d0e1f2_add_event_suggestions_table.py
+++ b/server/alembic/versions/a7b8c9d0e1f2_add_event_suggestions_table.py
@@ -1,0 +1,46 @@
+"""add event suggestions table
+
+Revision ID: a7b8c9d0e1f2
+Revises: d4e5f6a7b8c9
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a7b8c9d0e1f2"
+down_revision: Union[str, Sequence[str], None] = "d4e5f6a7b8c9"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "event_suggestions",
+        sa.Column("id", sa.String(255), primary_key=True),
+        sa.Column("user_id", sa.String(255), sa.ForeignKey("users.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("line_item_id", sa.String(255), sa.ForeignKey("line_items.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("event_hint_id", sa.String(255), sa.ForeignKey("event_hints.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("suggested_name", sa.String(255), nullable=False),
+        sa.Column("category_id", sa.String(255), sa.ForeignKey("categories.id", ondelete="SET NULL"), nullable=True),
+        sa.Column("rejected_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.TIMESTAMP(timezone=True), server_default=sa.func.now(), onupdate=sa.func.now()),
+        sa.UniqueConstraint("user_id", "line_item_id", name="uq_event_suggestion_user_line_item"),
+    )
+    op.create_index("ix_event_suggestions_user_id", "event_suggestions", ["user_id"])
+    op.create_index("ix_event_suggestions_line_item_id", "event_suggestions", ["line_item_id"])
+    op.create_index(
+        "ix_event_suggestions_user_pending",
+        "event_suggestions",
+        ["user_id", "rejected_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_event_suggestions_user_pending", table_name="event_suggestions")
+    op.drop_index("ix_event_suggestions_line_item_id", table_name="event_suggestions")
+    op.drop_index("ix_event_suggestions_user_id", table_name="event_suggestions")
+    op.drop_table("event_suggestions")

--- a/server/application.py
+++ b/server/application.py
@@ -9,7 +9,7 @@ from dotenv import load_dotenv
 from flask import Response, jsonify, request
 from flask_bcrypt import Bcrypt
 from flask_cors import CORS
-from flask_jwt_extended import JWTManager, jwt_required
+from flask_jwt_extended import JWTManager, get_current_user, jwt_required
 from venmo_api.models.user import User
 from werkzeug.exceptions import HTTPException
 
@@ -37,6 +37,7 @@ from resources.auth import auth_blueprint
 from resources.category import categories_blueprint
 from resources.event import events_blueprint
 from resources.event_hint import event_hints_blueprint
+from resources.event_suggestion import event_suggestions_blueprint
 from resources.line_item import all_line_items, line_items_blueprint
 from resources.manual_transaction import manual_transaction_blueprint
 from resources.monthly_breakdown import monthly_breakdown_blueprint
@@ -53,6 +54,7 @@ from resources.stripe import (
 )
 from resources.tags import tags_blueprint
 from resources.venmo import refresh_venmo, venmo_blueprint, venmo_to_line_items
+from utils.event_suggestions import generate_event_suggestions
 
 # Configure logging to stdout for cloud compatibility
 # Logs are treated as event streams that can be aggregated by cloud platforms
@@ -129,6 +131,7 @@ application.register_blueprint(manual_transaction_blueprint)
 application.register_blueprint(stripe_blueprint)
 application.register_blueprint(tags_blueprint)
 application.register_blueprint(event_hints_blueprint)
+application.register_blueprint(event_suggestions_blueprint)
 application.register_blueprint(categories_blueprint)
 
 # If an environment variable is not found in the .env file,
@@ -178,6 +181,7 @@ def schedule_refresh_api() -> tuple[Response, int]:
     try:
         refresh_all()
         create_consistent_line_items()
+        generate_event_suggestions()
     except Exception as e:
         logger.error("Error refreshing all: " + str(e))
         return jsonify({"error": "Refresh failed"}), 500
@@ -189,7 +193,12 @@ def schedule_refresh_api() -> tuple[Response, int]:
 def refresh_all_api() -> tuple[Response, int]:
     refresh_all()
     create_consistent_line_items()
-    line_items: List[Dict[str, Any]] = all_line_items(only_line_items_to_review=True)
+    user_id = get_current_user()["id"]
+    generate_event_suggestions(user_id)
+    line_items: List[Dict[str, Any]] = all_line_items(
+        only_line_items_to_review=True,
+        suggestion_user_id=user_id,
+    )
     return jsonify({"data": line_items}), 200
 
 
@@ -221,6 +230,8 @@ def refresh_single_account_api() -> tuple[Response, int]:
             splitwise_to_line_items()
         else:
             return jsonify({"error": f"Invalid source: {source}"}), 400
+
+        generate_event_suggestions(get_current_user()["id"])
 
         return jsonify({"message": "success"}), 200
 

--- a/server/models/sql_models.py
+++ b/server/models/sql_models.py
@@ -259,3 +259,29 @@ class EventHint(Base):
     # Relationships
     user = relationship("User")
     prefill_category = relationship("Category")
+
+
+class EventSuggestion(Base):
+    """A materialized single-line-item event suggestion and its review state."""
+
+    __tablename__ = "event_suggestions"
+    __table_args__ = (UniqueConstraint("user_id", "line_item_id", name="uq_event_suggestion_user_line_item"),)
+
+    id = Column(String(255), primary_key=True)  # es_xxx
+    user_id = Column(String(255), ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    line_item_id = Column(String(255), ForeignKey("line_items.id", ondelete="CASCADE"), nullable=False, index=True)
+    event_hint_id = Column(String(255), ForeignKey("event_hints.id", ondelete="SET NULL"), nullable=True)
+    suggested_name = Column(String(255), nullable=False)
+    category_id = Column(String(255), ForeignKey("categories.id", ondelete="SET NULL"), nullable=True)
+    rejected_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    created_at = Column(TIMESTAMP(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at = Column(
+        TIMESTAMP(timezone=True),
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    user = relationship("User")
+    line_item = relationship("LineItem")
+    event_hint = relationship("EventHint")
+    category = relationship("Category")

--- a/server/queries.py
+++ b/server/queries.py
@@ -30,6 +30,7 @@ def get_all_line_items(
     limit: Optional[int] = None,
     offset: int = 0,
     event_id: Optional[str] = None,
+    suggestion_user_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     """Get line items from PostgreSQL"""
     from models.database import SessionLocal
@@ -84,7 +85,7 @@ def get_all_line_items(
         if limit is not None:
             query = query.limit(limit)
 
-        return [
+        line_items = [
             {
                 "id": row.id,
                 "transaction_id": row.transaction_id,
@@ -102,6 +103,42 @@ def get_all_line_items(
             }
             for row in query.all()
         ]
+
+        if suggestion_user_id and line_items:
+            from models.sql_models import Category, EventHint, EventSuggestion
+
+            suggestions = (
+                db.query(
+                    EventSuggestion.id,
+                    EventSuggestion.line_item_id,
+                    EventSuggestion.suggested_name,
+                    EventSuggestion.category_id,
+                    Category.name.label("category"),
+                    EventHint.name.label("matched_hint_name"),
+                )
+                .join(Category, EventSuggestion.category_id == Category.id)
+                .outerjoin(EventHint, EventSuggestion.event_hint_id == EventHint.id)
+                .filter(
+                    EventSuggestion.user_id == suggestion_user_id,
+                    EventSuggestion.rejected_at.is_(None),
+                    EventSuggestion.line_item_id.in_([item["id"] for item in line_items]),
+                )
+                .all()
+            )
+            suggestions_by_line_item = {
+                row.line_item_id: {
+                    "id": row.id,
+                    "name": row.suggested_name,
+                    "category_id": row.category_id,
+                    "category": row.category,
+                    "matched_hint_name": row.matched_hint_name,
+                }
+                for row in suggestions
+            }
+            for line_item in line_items:
+                line_item["event_suggestion"] = suggestions_by_line_item.get(line_item["id"])
+
+        return line_items
 
 
 def get_line_item_by_id(id: str) -> Optional[Dict[str, Any]]:

--- a/server/resources/event_hint.py
+++ b/server/resources/event_hint.py
@@ -103,7 +103,7 @@ def create_event_hint() -> tuple[Response, int]:
         # Validate category if provided
         prefill_category_id = data.get("prefill_category_id")
         if prefill_category_id:
-            category = db.query(Category).filter(Category.id == prefill_category_id).first()
+            category = db.query(Category).filter(Category.id == prefill_category_id, Category.user_id == user_id).first()
             if not category:
                 return jsonify({"error": f"Category not found: {prefill_category_id}"}), 400
 
@@ -151,7 +151,7 @@ def update_event_hint(hint_id: str) -> tuple[Response, int]:
         if "prefill_category_id" in data:
             prefill_category_id = data["prefill_category_id"]
             if prefill_category_id:
-                category = db.query(Category).filter(Category.id == prefill_category_id).first()
+                category = db.query(Category).filter(Category.id == prefill_category_id, Category.user_id == user_id).first()
                 if not category:
                     return jsonify({"error": f"Category not found: {prefill_category_id}"}), 400
             hint.prefill_category_id = prefill_category_id

--- a/server/resources/event_suggestion.py
+++ b/server/resources/event_suggestion.py
@@ -1,0 +1,86 @@
+"""Review endpoints for materialized single-line-item event suggestions."""
+
+from datetime import UTC, datetime
+from typing import Any
+
+from flask import Blueprint, Response, jsonify, request
+from flask_jwt_extended import get_current_user, jwt_required
+
+from models.database import SessionLocal
+from models.sql_models import EventLineItem, EventSuggestion
+from serializers import serialize_datetime
+from utils.pg_event_operations import upsert_event_to_postgresql
+
+event_suggestions_blueprint = Blueprint("event_suggestions", __name__)
+
+
+@event_suggestions_blueprint.route("/api/event-suggestions/<suggestion_id>/accept", methods=["POST"])
+@jwt_required()
+def accept_event_suggestion(suggestion_id: str) -> tuple[Response, int]:
+    """Create the suggested event, optionally overriding its title."""
+    user_id = get_current_user()["id"]
+    data: dict[str, Any] = request.get_json(silent=True) or {}
+
+    with SessionLocal.begin() as db:
+        suggestion = (
+            db.query(EventSuggestion)
+            .filter(
+                EventSuggestion.id == suggestion_id,
+                EventSuggestion.user_id == user_id,
+                EventSuggestion.rejected_at.is_(None),
+            )
+            .with_for_update()
+            .first()
+        )
+        if not suggestion:
+            return jsonify({"error": "Event suggestion not found"}), 404
+
+        name = str(data.get("name", suggestion.suggested_name)).strip()
+        if not name:
+            return jsonify({"error": "Event name is required"}), 400
+        if not suggestion.category:
+            return jsonify({"error": "Suggested category is no longer available"}), 409
+
+        already_reviewed = db.query(EventLineItem.id).filter(EventLineItem.line_item_id == suggestion.line_item_id).first()
+        if already_reviewed:
+            db.delete(suggestion)
+            return jsonify({"error": "Line item has already been added to an event"}), 409
+
+        line_item = suggestion.line_item
+        event_dict = {
+            "name": name,
+            "category": suggestion.category.name,
+            "date": serialize_datetime(line_item.date),
+            "line_items": [line_item.id],
+            "is_duplicate_transaction": False,
+            "tags": [],
+        }
+        event_id = upsert_event_to_postgresql(event_dict, db, user_id)
+
+        return (
+            jsonify(
+                {
+                    "id": event_id,
+                    **event_dict,
+                    "amount": float(line_item.amount),
+                }
+            ),
+            201,
+        )
+
+
+@event_suggestions_blueprint.route("/api/event-suggestions/<suggestion_id>/reject", methods=["POST"])
+@jwt_required()
+def reject_event_suggestion(suggestion_id: str) -> tuple[Response, int]:
+    """Permanently suppress a suggestion for this user and line item."""
+    user_id = get_current_user()["id"]
+
+    with SessionLocal.begin() as db:
+        suggestion = (
+            db.query(EventSuggestion).filter(EventSuggestion.id == suggestion_id, EventSuggestion.user_id == user_id).first()
+        )
+        if not suggestion:
+            return jsonify({"error": "Event suggestion not found"}), 404
+        suggestion.rejected_at = datetime.now(UTC)
+
+    return Response(status=204), 204

--- a/server/resources/line_item.py
+++ b/server/resources/line_item.py
@@ -5,7 +5,7 @@ from decimal import Decimal, InvalidOperation
 from typing import Any, Dict, List, Optional
 
 from flask import Blueprint, Response, jsonify, request
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import get_current_user, jwt_required
 
 from helpers import html_date_to_posix, sort_by_date_description, str_to_bool
 from models.database import SessionLocal
@@ -91,7 +91,13 @@ def all_line_items_api() -> tuple[Response, int]:
     payment_method: Optional[str] = request.args.get("payment_method")
     limit: Optional[int] = int(request.args["limit"]) if "limit" in request.args else None
     offset: int = int(request.args.get("offset", 0))
-    line_items: List[Dict[str, Any]] = all_line_items(only_line_items_to_review, payment_method, limit, offset)
+    line_items: List[Dict[str, Any]] = all_line_items(
+        only_line_items_to_review,
+        payment_method,
+        limit,
+        offset,
+        suggestion_user_id=get_current_user()["id"],
+    )
     line_items_total: float = sum(line_item["amount"] for line_item in line_items)
     logger.info(f"Retrieved {len(line_items)} line items (total: ${line_items_total:.2f})")
     return jsonify({"total": line_items_total, "data": line_items}), 200
@@ -102,12 +108,14 @@ def all_line_items(
     payment_method: Optional[str] = None,
     limit: Optional[int] = None,
     offset: int = 0,
+    suggestion_user_id: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
     line_items: List[Dict[str, Any]] = get_all_line_items(
         payment_method=payment_method,
         only_unreviewed=bool(only_line_items_to_review),
         limit=limit,
         offset=offset,
+        suggestion_user_id=suggestion_user_id,
     )
     line_items = sort_by_date_description(line_items)
     return line_items

--- a/server/resources/splitwise.py
+++ b/server/resources/splitwise.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List
 
 from apiflask import APIBlueprint, abort
 from flask import Response, jsonify
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import get_current_user, jwt_required
 from splitwise.expense import Expense
 from splitwise.user import ExpenseUser
 
@@ -21,6 +21,7 @@ from resources.schemas.splitwise import (
     SplitwiseExpenseCreateResponse,
     SplitwiseFriendListResponse,
 )
+from utils.event_suggestions import generate_event_suggestions
 from utils.pg_bulk_ops import (
     bulk_upsert_line_items,
     bulk_upsert_transactions,
@@ -49,6 +50,7 @@ def refresh_splitwise_api() -> tuple[Response, int]:
     try:
         refresh_splitwise()
         splitwise_to_line_items()
+        generate_event_suggestions(get_current_user()["id"])
         return jsonify("Refreshed Splitwise Connection"), 200
     except Exception as e:
         logger.error(f"Splitwise refresh failed: {e}", exc_info=True)

--- a/server/resources/stripe.py
+++ b/server/resources/stripe.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional
 import requests  # Still needed for Authorization endpoint (not yet in SDK)
 import stripe
 from flask import Blueprint, Response, jsonify, request
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import get_current_user, jwt_required
 
 from constants import BATCH_SIZE, STRIPE_API_KEY, STRIPE_CUSTOMER_EMAIL, STRIPE_CUSTOMER_ID, STRIPE_CUSTOMER_NAME
 from helpers import cents_to_dollars, flip_amount
@@ -14,6 +14,7 @@ from queries import (
     get_transactions,
 )
 from resources.line_item import LineItem
+from utils.event_suggestions import generate_event_suggestions
 from utils.pg_bulk_ops import (
     bulk_upsert_bank_accounts,
     bulk_upsert_line_items,
@@ -135,6 +136,7 @@ def refresh_account_balances(account_ids: Optional[List[str]] = None) -> int:
 @jwt_required()
 def refresh_stripe_api() -> tuple[Response, int]:
     refresh_stripe()
+    generate_event_suggestions(get_current_user()["id"])
     return jsonify("Refreshed Stripe Connection"), 200
 
 

--- a/server/resources/venmo.py
+++ b/server/resources/venmo.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Dict, List
 
 from flask import Blueprint, Response, jsonify
-from flask_jwt_extended import jwt_required
+from flask_jwt_extended import get_current_user, jwt_required
 from venmo_api.models.user import User
 
 from clients import get_venmo_client
@@ -11,6 +11,7 @@ from helpers import flip_amount
 from models.database import SessionLocal
 from queries import get_transactions
 from resources.line_item import LineItem
+from utils.event_suggestions import generate_event_suggestions
 from utils.pg_bulk_ops import bulk_upsert_line_items, bulk_upsert_transactions
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,7 @@ def refresh_venmo_api() -> tuple[Response, int]:
     try:
         refresh_venmo()
         venmo_to_line_items()
+        generate_event_suggestions(get_current_user()["id"])
         return jsonify("Refreshed Venmo Connection"), 200
     except Exception as e:
         logger.error(f"Venmo refresh failed: {e}", exc_info=True)

--- a/server/tests/conftest.py
+++ b/server/tests/conftest.py
@@ -35,6 +35,7 @@ from resources.auth import auth_blueprint
 from resources.category import categories_blueprint
 from resources.event import events_blueprint
 from resources.event_hint import event_hints_blueprint
+from resources.event_suggestion import event_suggestions_blueprint
 from resources.line_item import line_items_blueprint
 from resources.manual_transaction import manual_transaction_blueprint
 from resources.monthly_breakdown import monthly_breakdown_blueprint
@@ -113,6 +114,7 @@ def flask_app():
     app.register_blueprint(manual_transaction_blueprint)
     app.register_blueprint(categories_blueprint)
     app.register_blueprint(event_hints_blueprint)
+    app.register_blueprint(event_suggestions_blueprint)
     app.register_blueprint(line_items_blueprint)
     app.register_blueprint(events_blueprint)
     app.register_blueprint(monthly_breakdown_blueprint)

--- a/server/tests/test_event_suggestions.py
+++ b/server/tests/test_event_suggestions.py
@@ -1,0 +1,114 @@
+from datetime import UTC, datetime
+
+from models.sql_models import Category, Event, EventHint, EventLineItem, EventSuggestion, LineItem, PaymentMethod, Transaction
+from utils.event_suggestions import generate_event_suggestions
+
+
+def create_matching_line_item_and_hint(pg_session, *, category: bool = True):
+    payment_method = pg_session.query(PaymentMethod).first()
+    subscription = pg_session.query(Category).filter_by(user_id="user_id", name="Subscription").first()
+    transaction = Transaction(
+        id="txn_suggestion",
+        source="manual",
+        source_id="suggestion_source",
+        source_data={},
+        transaction_date=datetime.now(UTC),
+    )
+    line_item = LineItem(
+        id="li_suggestion",
+        transaction_id=transaction.id,
+        date=datetime.now(UTC),
+        description="Spotify Premium",
+        amount=12.99,
+        payment_method_id=payment_method.id,
+    )
+    hint = EventHint(
+        id="eh_suggestion",
+        user_id="user_id",
+        name="Spotify purchases",
+        cel_expression='description.contains("Spotify")',
+        prefill_name="Spotify",
+        prefill_category_id=subscription.id if category else None,
+        display_order=0,
+        is_active=True,
+    )
+    pg_session.add_all([transaction, line_item, hint])
+    pg_session.commit()
+    return line_item, subscription
+
+
+def test_refresh_generation_materializes_matching_categorized_hint(pg_session, test_client, jwt_token):
+    line_item, _ = create_matching_line_item_and_hint(pg_session)
+
+    assert generate_event_suggestions("user_id") == 1
+
+    response = test_client.get(
+        "/api/line_items?only_line_items_to_review=true",
+        headers={"Authorization": f"Bearer {jwt_token}"},
+    )
+    suggestion = next(item for item in response.get_json()["data"] if item["id"] == line_item.id)["event_suggestion"]
+    assert suggestion["name"] == "Spotify"
+    assert suggestion["category"] == "Subscription"
+    assert suggestion["matched_hint_name"] == "Spotify purchases"
+
+
+def test_hint_without_category_does_not_create_quick_suggestion(pg_session):
+    create_matching_line_item_and_hint(pg_session, category=False)
+
+    assert generate_event_suggestions("user_id") == 0
+    assert pg_session.query(EventSuggestion).count() == 0
+
+
+def test_rejected_suggestion_is_not_regenerated(pg_session, test_client, jwt_token):
+    create_matching_line_item_and_hint(pg_session)
+    generate_event_suggestions("user_id")
+    suggestion = pg_session.query(EventSuggestion).one()
+
+    response = test_client.post(
+        f"/api/event-suggestions/{suggestion.id}/reject",
+        headers={"Authorization": f"Bearer {jwt_token}"},
+    )
+
+    pg_session.expire_all()
+    assert response.status_code == 204
+    assert pg_session.query(EventSuggestion).one().rejected_at is not None
+    assert generate_event_suggestions("user_id") == 0
+
+
+def test_accepting_suggestion_with_edited_title_creates_event_and_deletes_suggestion(pg_session, test_client, jwt_token):
+    line_item, _ = create_matching_line_item_and_hint(pg_session)
+    generate_event_suggestions("user_id")
+    suggestion = pg_session.query(EventSuggestion).one()
+
+    response = test_client.post(
+        f"/api/event-suggestions/{suggestion.id}/accept",
+        json={"name": "My Spotify subscription"},
+        headers={"Authorization": f"Bearer {jwt_token}"},
+    )
+
+    pg_session.expire_all()
+    assert response.status_code == 201
+    assert response.get_json()["name"] == "My Spotify subscription"
+    event = pg_session.query(Event).one()
+    assert event.description == "My Spotify subscription"
+    assert pg_session.query(EventLineItem).filter_by(event_id=event.id, line_item_id=line_item.id).one()
+    assert pg_session.query(EventSuggestion).count() == 0
+
+
+def test_normal_event_creation_also_deletes_suggestion(pg_session, test_client, jwt_token):
+    line_item, _ = create_matching_line_item_and_hint(pg_session)
+    generate_event_suggestions("user_id")
+
+    response = test_client.post(
+        "/api/events",
+        json={
+            "name": "Created normally",
+            "category": "Subscription",
+            "line_items": [line_item.id],
+        },
+        headers={"Authorization": f"Bearer {jwt_token}"},
+    )
+
+    pg_session.expire_all()
+    assert response.status_code == 201
+    assert pg_session.query(EventSuggestion).count() == 0

--- a/server/utils/event_suggestions.py
+++ b/server/utils/event_suggestions.py
@@ -1,0 +1,97 @@
+"""Materialize event-hint matches for unreviewed line items."""
+
+import logging
+
+from sqlalchemy import and_
+from sqlalchemy.orm import joinedload
+
+from models.database import SessionLocal
+from models.sql_models import Category, EventHint, EventLineItem, EventSuggestion, LineItem, User
+from utils.cel_evaluator import evaluate_hints
+from utils.id_generator import generate_id
+
+logger = logging.getLogger(__name__)
+
+
+def generate_event_suggestions(user_id: str | None = None) -> int:
+    """Create missing single-line-item suggestions. Existing and rejected records are preserved."""
+    created_count = 0
+
+    with SessionLocal.begin() as db:
+        user_ids = [user_id] if user_id else [row.id for row in db.query(User.id).all()]
+
+        for current_user_id in user_ids:
+            hints = (
+                db.query(EventHint)
+                .options(joinedload(EventHint.prefill_category))
+                .join(Category, EventHint.prefill_category_id == Category.id)
+                .filter(
+                    EventHint.user_id == current_user_id,
+                    Category.user_id == current_user_id,
+                    EventHint.is_active == True,  # noqa: E712
+                    EventHint.prefill_category_id.is_not(None),
+                )
+                .order_by(EventHint.display_order)
+                .all()
+            )
+            if not hints:
+                continue
+
+            line_items = (
+                db.query(LineItem)
+                .options(joinedload(LineItem.payment_method))
+                .outerjoin(EventLineItem, EventLineItem.line_item_id == LineItem.id)
+                .outerjoin(
+                    EventSuggestion,
+                    and_(
+                        EventSuggestion.line_item_id == LineItem.id,
+                        EventSuggestion.user_id == current_user_id,
+                    ),
+                )
+                .filter(EventLineItem.id.is_(None), EventSuggestion.id.is_(None))
+                .all()
+            )
+
+            hint_dicts = [
+                {
+                    "id": hint.id,
+                    "name": hint.name,
+                    "cel_expression": hint.cel_expression,
+                    "prefill_name": hint.prefill_name,
+                    "prefill_category": hint.prefill_category.name,
+                    "is_active": hint.is_active,
+                }
+                for hint in hints
+            ]
+            hints_by_id = {hint.id: hint for hint in hints}
+
+            for line_item in line_items:
+                suggestion = evaluate_hints(
+                    hint_dicts,
+                    [
+                        {
+                            "description": line_item.description or "",
+                            "amount": float(line_item.amount or 0),
+                            "payment_method": line_item.payment_method.name if line_item.payment_method else "",
+                            "responsible_party": line_item.responsible_party or "",
+                        }
+                    ],
+                )
+                if not suggestion:
+                    continue
+
+                matched_hint = hints_by_id[suggestion["matched_hint_id"]]
+                db.add(
+                    EventSuggestion(
+                        id=generate_id("es"),
+                        user_id=current_user_id,
+                        line_item_id=line_item.id,
+                        event_hint_id=matched_hint.id,
+                        suggested_name=matched_hint.prefill_name,
+                        category_id=matched_hint.prefill_category_id,
+                    )
+                )
+                created_count += 1
+
+    logger.info("Created %s event suggestions", created_count)
+    return created_count

--- a/server/utils/pg_event_operations.py
+++ b/server/utils/pg_event_operations.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from typing import Any, Dict
 
 from models.database import SessionLocal
-from models.sql_models import Category, Event, EventLineItem, EventTag, LineItem, Tag
+from models.sql_models import Category, Event, EventLineItem, EventSuggestion, EventTag, LineItem, Tag
 from utils.id_generator import generate_id
 
 logger = logging.getLogger(__name__)
@@ -35,7 +35,7 @@ def upsert_event_to_postgresql(event_dict: Dict[str, Any], db_session, user_id: 
     if not category_name:
         raise ValueError(f"Event {event_dict.get('id')} has no category - cannot write to PostgreSQL")
 
-    category = db_session.query(Category).filter(Category.name == category_name).first()
+    category = db_session.query(Category).filter(Category.name == category_name, Category.user_id == user_id).first()
     if not category:
         raise ValueError(f"Category '{category_name}' not found in PostgreSQL - cannot write event")
 
@@ -76,6 +76,9 @@ def upsert_event_to_postgresql(event_dict: Dict[str, Any], db_session, user_id: 
     # Create EventLineItem junctions (batch-fetch to avoid N+1)
     line_item_ids = [str(id) for id in event_dict.get("line_items", [])]
     if line_item_ids:
+        db_session.query(EventSuggestion).filter(EventSuggestion.line_item_id.in_(line_item_ids)).delete(
+            synchronize_session=False
+        )
         pg_line_items = db_session.query(LineItem).filter(LineItem.id.in_(line_item_ids)).all()
         found_ids = {li.id for li in pg_line_items}
         for li_id in line_item_ids:


### PR DESCRIPTION
## What changed

- Materialize categorized event-hint matches for newly refreshed, unreviewed line items.
- Add durable accept and dismiss decisions, with atomic event creation and cleanup when line items are assigned normally.
- Surface editable single-line-item suggestions directly in the review workflow on desktop and mobile.
- Visually attach each suggestion to its line item with a subtle gray background, connector, explicit copy, and clearer actions.
- Improve line-item detail navigation with direct actions.
- Add the `event_suggestions` database migration and focused server/client coverage.

## Why

Many events contain one line item and can be classified entirely from an existing event hint. Presenting those matches immediately after refresh removes the repeated selection and modal workflow while preserving user review and permanent dismissal.

## Impact

Users can edit a suggested event title, create the event in one action, or dismiss the suggestion so it does not return for that line item. Hints without categories continue to use the existing modal-prefill behavior.

The migration must be applied with DDL-capable PostgreSQL credentials before deploying the application code:

```bash
uv run alembic upgrade head
```

## Validation

- Server: 297 tests passed
- Client: full 689-test suite passed during feature implementation
- Latest UI/navigation refinements: 80 focused tests passed
- TypeScript typecheck passed
- Production client build passed
- Ruff lint and formatting passed